### PR TITLE
DCM-923 - changed data lock orchestrator to throw an exception if the…

### DIFF
--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests/Orchestrators/DataLock/WhenGettingApprenticeshipDataLockMismatches.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests/Orchestrators/DataLock/WhenGettingApprenticeshipDataLockMismatches.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using MediatR;
@@ -7,15 +8,16 @@ using NUnit.Framework;
 
 using SFA.DAS.Commitments.Api.Types.Apprenticeship;
 using SFA.DAS.Commitments.Api.Types.DataLock;
+using SFA.DAS.Commitments.Api.Types.DataLock.Types;
 using SFA.DAS.ProviderApprenticeshipsService.Application.Queries.GetApprenticeship;
 using SFA.DAS.ProviderApprenticeshipsService.Application.Queries.GetApprenticeshipDataLockSummary;
 using SFA.DAS.ProviderApprenticeshipsService.Application.Queries.GetApprenticeshipPriceHistory;
 using SFA.DAS.ProviderApprenticeshipsService.Domain.Interfaces;
 using SFA.DAS.ProviderApprenticeshipsService.Web.Models.DataLock;
 using SFA.DAS.ProviderApprenticeshipsService.Web.Orchestrators;
-using SFA.DAS.ProviderApprenticeshipsService.Web.Orchestrators.ApprovedApprenticeshipValidation;
 using SFA.DAS.ProviderApprenticeshipsService.Web.Orchestrators.Mappers;
 using SFA.DAS.HashingService;
+using SFA.DAS.ProviderApprenticeshipsService.Web.Exceptions;
 
 namespace SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests.Orchestrators.DataLock
 {
@@ -25,6 +27,8 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests.Orchestrators.Dat
         private DataLockOrchestrator _orchestrator;
         private Mock<IMediator> _mediator;
         private Mock<IDataLockMapper> _mapper;
+
+        private const long EventId = 123L;
 
         [SetUp]
         public void Arrange()
@@ -49,10 +53,15 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests.Orchestrators.Dat
                 });
 
             _mapper = new Mock<IDataLockMapper>();
+           
+            // Arrange
             _mapper.Setup(x => x.MapDataLockSummary(It.IsAny<DataLockSummary>(), It.IsAny<bool>()))
                 .ReturnsAsync(() => new DataLockSummaryViewModel
                 {
-                    DataLockWithCourseMismatch = new List<DataLockViewModel>(),
+                    DataLockWithCourseMismatch = new List<DataLockViewModel>
+                    {
+                        new DataLockViewModel {DataLockEventId = EventId, DataLockErrorCode = DataLockErrorCode.Dlock07, IlrEffectiveFromDate = DateTime.Today, TriageStatusViewModel = TriageStatusViewModel.Unknown}
+                    },
                     DataLockWithOnlyPriceMismatch = new List<DataLockViewModel>()
                 });
 
@@ -93,6 +102,33 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests.Orchestrators.Dat
 
             //Assert
             _mapper.Verify(x => x.MapDataLockSummary(It.IsAny<DataLockSummary>(), It.IsAny<bool>()), Times.Once);
+        }
+
+        [Test]
+        public async Task ThenConfirmRestartGetsCorrectDataLockEvent()
+        {
+            // Act
+            var result = await _orchestrator.GetConfirmRestartViewModel(1, "TEST");
+
+            // Assert
+            Assert.AreEqual(EventId, result.DataLockEventId);
+        }
+
+        [Test]
+        public void ThenConfirmRestartThrowsWhenNoDataLockExists()
+        {
+            // Arrange
+            _mapper.Setup(x => x.MapDataLockSummary(It.IsAny<DataLockSummary>(), It.IsAny<bool>()))
+                .ReturnsAsync(() => new DataLockSummaryViewModel
+                {
+                    DataLockWithCourseMismatch = new List<DataLockViewModel>(),
+                    DataLockWithOnlyPriceMismatch = new List<DataLockViewModel>()
+                });
+
+            Assert.ThrowsAsync<InvalidStateException>(async () =>
+            {
+                await _orchestrator.GetConfirmRestartViewModel(1, "TEST");
+            });
         }
     }
 }

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Models/DataLock/DataLockMismatchViewModel.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Models/DataLock/DataLockMismatchViewModel.cs
@@ -26,5 +26,7 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.Models.DataLock
         public IEnumerable<CourseDataLockViewModel> CourseDataLocks { get; set; }
 
         public int TotalChanges => (PriceDataLocks?.Count() ?? 0) + (CourseDataLocks?.Count() ?? 0);
+
+        public DataLockViewModel DataLockEvent { get; set; }
     }
 }

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/DataLock/RequestRestart.cshtml
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/DataLock/RequestRestart.cshtml
@@ -1,16 +1,12 @@
-﻿@using SFA.DAS.Commitments.Api.Types.DataLock.Types
-@using SFA.DAS.ProviderApprenticeshipsService.Web.Extensions
+﻿@using SFA.DAS.ProviderApprenticeshipsService.Web.Extensions
 @using SFA.DAS.ProviderApprenticeshipsService.Web.Models.DataLock
-@model SFA.DAS.ProviderApprenticeshipsService.Web.Models.DataLock.DataLockMismatchViewModel
+@model DataLockMismatchViewModel
 
 @{
     ViewBag.Title = "Request restart";
     ViewBag.PageId = "course-mismatch";
 
-    var datalock = Model.DataLockSummaryViewModel.DataLockWithCourseMismatch
-.Where(x => x.TriageStatusViewModel == TriageStatusViewModel.Unknown)
-.OrderBy(x => x.IlrEffectiveFromDate)
-.First();
+    var datalock = Model.DataLockEvent;
 }
 
 


### PR DESCRIPTION
… matching data lock event does not exist. Updated VM to include the DataLockEvent so the logic could be removed from the RequestRestart view