### PR TITLE
Dpp 1176 provider transfer final approver ui notification (#348)

### DIFF
--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests/Orchestrators/Commitments/WhenGettingAcknowledgementViewModel.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests/Orchestrators/Commitments/WhenGettingAcknowledgementViewModel.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Commitments.Api.Types.Commitment;
+using SFA.DAS.ProviderApprenticeshipsService.Application.Queries.GetCommitment;
+
+namespace SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests.Orchestrators.Commitments
+{
+    [TestFixture]
+    public class WhenGettingAcknowledgementViewModel: ApprenticeshipValidationTestBase
+    {
+        private CommitmentView _commitment;
+
+        public override void SetUp()
+        {
+            _commitment = new CommitmentView
+            {
+                Messages = new List<MessageView>()
+            };
+
+            _mockMediator.Setup(x => x.SendAsync(It.IsAny<GetCommitmentQueryRequest>()))
+                .ReturnsAsync(() => new GetCommitmentQueryResponse
+                {
+                    Commitment = _commitment
+                });
+
+            base.SetUp();
+        }
+
+        [Test]
+        public async Task ThenARequestForTheCommitmentDataIsMade()
+        {
+            await _orchestrator.GetAcknowledgementViewModel(1, "Hashed-Id", Web.Models.Types.SaveStatus.ApproveAndSend);
+
+            _mockMediator.Verify(x => x.SendAsync(It.IsAny<GetCommitmentQueryRequest>()),
+                Times.Once);
+        }
+    }
+}

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests/Orchestrators/Commitments/WhenGettingApprovedViewModel.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests/Orchestrators/Commitments/WhenGettingApprovedViewModel.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Commitments.Api.Types;
+using SFA.DAS.Commitments.Api.Types.Commitment;
+using SFA.DAS.Commitments.Api.Types.Commitment.Types;
+using SFA.DAS.ProviderApprenticeshipsService.Application.Queries.GetCommitment;
+using SFA.DAS.ProviderApprenticeshipsService.Application.Queries.GetCommitments;
+using SFA.DAS.ProviderApprenticeshipsService.Web.Models;
+
+namespace SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests.Orchestrators.Commitments
+{
+    [TestFixture]
+    public class WhenGettingApprovedViewModel : ApprenticeshipValidationTestBase
+    {
+        private CommitmentView _commitment;
+        private List<CommitmentListItem> _otherCommitments;
+
+        public override void SetUp()
+        {
+            _commitment = new CommitmentView
+            {
+                Messages = new List<MessageView>()
+            };
+
+            _otherCommitments = new List<CommitmentListItem>();
+
+            _mockMediator.Setup(x => x.SendAsync(It.IsAny<GetCommitmentQueryRequest>()))
+                .ReturnsAsync(() => new GetCommitmentQueryResponse
+                {
+                    Commitment = _commitment
+                });
+
+            _mockMediator.Setup(x => x.SendAsync(It.IsAny<GetCommitmentsQueryRequest>()))
+                .ReturnsAsync(() => new GetCommitmentsQueryResponse
+                {
+                    Commitments = _otherCommitments
+                });
+
+            base.SetUp();
+        }
+
+        [Test]
+        public async Task ThenARequestForTheCommitmentDataIsMade()
+        {
+            await _orchestrator.GetApprovedViewModel(1, "Hashed-Id");
+
+            _mockMediator.Verify(x => x.SendAsync(It.IsAny<GetCommitmentQueryRequest>()),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task ThenTheViewModelShouldIndicateWhenThereAreOtherCohortsInSameStatus()
+        {
+            _otherCommitments.Add(new CommitmentListItem
+            {
+                ApprenticeshipCount = 10,
+                AgreementStatus = AgreementStatus.EmployerAgreed,
+                CanBeApproved = true,
+                EditStatus = EditStatus.ProviderOnly,
+                LastAction = LastAction.Approve
+            });
+
+            _mockCalculator.Setup(x => x.GetStatus(
+                    It.IsAny<EditStatus>(),
+                    It.IsAny<int>(),
+                    It.IsAny<LastAction>(),
+                    It.IsAny<AgreementStatus>(),
+                    It.IsAny<LastUpdateInfo>()))
+                .Returns(RequestStatus.ReadyForApproval);
+
+            var result = await _orchestrator.GetApprovedViewModel(1, "Hashed-Id");
+
+            Assert.IsTrue(result.HasOtherCohortsAwaitingApproval);
+        }
+
+        [Test]
+        public async Task ThenTheViewModelShouldIndicateWhenThereAreNotOtherCohortsInSameStatus()
+        {
+            var result = await _orchestrator.GetApprovedViewModel(1, "Hashed-Id");
+
+            Assert.IsFalse(result.HasOtherCohortsAwaitingApproval);
+        }
+
+        [TestCase(false, "Cohort approved")]
+        [TestCase(true, "Cohort approved and transfer request sent")]
+        public async Task ThenTheHeadlineShouldReflectWhetherTheCommitmentIsToBePaidByTransfer(bool isTransfer, string expectHeadline)
+        {
+            _commitment.TransferSenderId = isTransfer ? 1L : default(long?);
+
+            var result = await _orchestrator.GetApprovedViewModel(1, "Hashed-Id");
+
+            Assert.AreEqual(expectHeadline, result.Headline);
+        }
+
+        [Test]
+        public async Task ThenTheViewModelShouldIndicateWhenCohortIsForTransfer()
+        {
+            _commitment.TransferSenderId = 1L;
+
+            var result = await _orchestrator.GetApprovedViewModel(1, "Hashed-Id");
+
+            Assert.IsTrue(result.IsTransfer);
+        }
+
+        [Test]
+        public async Task ThenTheViewModelShouldIndicateWhenCohortIsNotForTransfer()
+        {
+            _commitment.TransferSenderId = null;
+
+            var result = await _orchestrator.GetApprovedViewModel(1, "Hashed-Id");
+
+            Assert.IsFalse(result.IsTransfer);
+        }
+    }
+}

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests.csproj
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests.csproj
@@ -132,7 +132,9 @@
     <Compile Include="Orchestrators\Commitments\Mappers\WhenMappingApprenticeshipFilters.cs" />
     <Compile Include="Orchestrators\Commitments\Mappers\WhenMappingApprenticeshipSearchQuery.cs" />
     <Compile Include="Orchestrators\Commitments\Mappers\WhenMappingDataLocks.cs" />
+    <Compile Include="Orchestrators\Commitments\WhenGettingAcknowledgementViewModel.cs" />
     <Compile Include="Orchestrators\Commitments\WhenGettingApprenticeship.cs" />
+    <Compile Include="Orchestrators\Commitments\WhenGettingApprovedViewModel.cs" />
     <Compile Include="Orchestrators\Commitments\WhenGettingCreateApprenticeshipViewModel.cs" />
     <Compile Include="Orchestrators\Commitments\WhenValidatingApprenticeshipViewModel.cs" />
     <Compile Include="Orchestrators\ManageApprentices\WhenCreatingApprenticeshipUpdate.cs" />

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Controllers/CommitmentController.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Controllers/CommitmentController.cs
@@ -382,22 +382,7 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.Controllers
         [Route("{hashedCommitmentId}/RequestApproved")]
         public async Task<ActionResult> Approved(long providerId, string hashedCommitmentId)
         {
-            var commitment = await _commitmentOrchestrator.GetCommitment(providerId, hashedCommitmentId);
-            var currentStatusCohortAny = await _commitmentOrchestrator.GetCohortsForCurrentStatus(providerId, RequestStatus.ReadyForApproval);
-            string url;
-            var linkText = "Return to Approve cohorts";
-            if (currentStatusCohortAny)
-            {
-                url = Url.Action("ReadyForReview", new { ProviderId = providerId });
-            }
-            else
-            {
-                url = Url.Action("Cohorts", "Commitment", new { ProviderId = providerId });
-                linkText = "Return to your cohorts";
-            }
-
-            var model = new AcknowledgementViewModel { CommitmentReference = commitment.Reference, EmployerName = commitment.LegalEntityName, ProviderName = commitment.ProviderName, Message = string.Empty, RedirectUrl = url, RedirectLinkText = linkText };
-
+            var model = await _commitmentOrchestrator.GetApprovedViewModel(providerId, hashedCommitmentId);
             return View("RequestApproved", model);
         }
 

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Models/ApprovedViewModel.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Models/ApprovedViewModel.cs
@@ -1,0 +1,12 @@
+﻿namespace SFA.DAS.ProviderApprenticeshipsService.Web.Models
+{
+    public class ApprovedViewModel
+    {
+        public string Headline { get; internal set; }
+        public string CommitmentReference { get; internal set; }
+        public string EmployerName { get; internal set; }
+        public string ProviderName { get; internal set; }
+        public bool HasOtherCohortsAwaitingApproval { get; internal set; }
+        public bool IsTransfer { get; internal set; }
+    }
+}

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Orchestrators/CommitmentOrchestrator.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Orchestrators/CommitmentOrchestrator.cs
@@ -799,6 +799,35 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.Orchestrators
             return result;
         }
 
+        public async Task<ApprovedViewModel> GetApprovedViewModel(long providerId, string hashedCommitmentId)
+        {
+            var commitmentId = _hashingService.DecodeValue(hashedCommitmentId);
+
+            _logger.Info($"Getting commitment:{commitmentId} for provider:{providerId}", providerId, commitmentId);
+
+            var commitmentData = await _mediator.SendAsync(new GetCommitmentQueryRequest
+            {
+                ProviderId = providerId,
+                CommitmentId = commitmentId
+            });
+
+            var commitment = commitmentData.Commitment;
+
+            var result = new ApprovedViewModel
+            {
+                Headline = commitment.TransferSenderId.HasValue
+                    ? "Cohort approved and transfer request sent"
+                    : "Cohort approved",
+                CommitmentReference = commitment.Reference,
+                EmployerName = commitment.LegalEntityName,
+                ProviderName = commitment.ProviderName,
+                IsTransfer = commitment.TransferSenderId.HasValue,
+                HasOtherCohortsAwaitingApproval = await GetCohortsForCurrentStatus(providerId, RequestStatus.ReadyForApproval)
+            };
+
+            return result;
+        }
+
         public async Task<Dictionary<string, string>> ValidateApprenticeship(ApprenticeshipViewModel viewModel)
         {
 

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/SFA.DAS.ProviderApprenticeshipsService.Web.csproj
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/SFA.DAS.ProviderApprenticeshipsService.Web.csproj
@@ -409,6 +409,7 @@
     <Compile Include="Models\ApprenticeshipListItemViewModel.cs" />
     <Compile Include="Models\ApprenticeshipUpdate\ApprenticeshipUpdateViewModel.cs" />
     <Compile Include="Models\ApprenticeshipUpdate\CreateApprenticeshipUpdateViewModel.cs" />
+    <Compile Include="Models\ApprovedViewModel.cs" />
     <Compile Include="Models\BulkUpload\CsvRecordMap.cs" />
     <Compile Include="Models\CourseDataLockViewModel.cs" />
     <Compile Include="Models\DataLock\ConfirmRestartViewModel.cs" />

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/Commitment/RequestApproved.cshtml
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/Commitment/RequestApproved.cshtml
@@ -1,4 +1,4 @@
-﻿@model SFA.DAS.ProviderApprenticeshipsService.Web.Models.AcknowledgementViewModel
+﻿@model SFA.DAS.ProviderApprenticeshipsService.Web.Models.ApprovedViewModel
 
 @{
     ViewBag.Title = "Request approved";
@@ -9,7 +9,7 @@
     <div class="column-full">
         <div class="govuk-box-highlight">
             <h1 class="heading-xlarge" id="changeHeadline">
-                Cohort approved
+                @Model.Headline
             </h1>
         </div>
     </div>
@@ -36,14 +36,33 @@
         </table>
 
         <h2 class="heading-medium">What happens next?</h2>
-        <p id="changeMainCopy">
-            Your cohort has been approved. To update the details for any apprentices in this cohort you will need to 
-            <a href="@Url.Action("Index" ,"ManageApprentices")">manage your apprentices</a>.
-        </p>
-
-        @if (!string.IsNullOrEmpty(Model.RedirectUrl))
+            
+        @if (Model.IsTransfer)
         {
-            <a href="@Model.RedirectUrl" aria-label="@Model.RedirectLinkText">@Model.RedirectLinkText</a>
+            <ul class="list list-bullet text">
+                <li>
+                    A transfer request has been sent to the employer who is funding this cohort
+                </li>
+                <li>
+                    Once the transfer request is approved, you'll be able to <a href="@Url.Action("Index", "ManageApprentices")">view and manage the apprentices</a>
+                </li>
+            </ul>
+        }
+        else
+        {
+            <p id="changeMainCopy">
+                Your cohort has been approved. To update the details for any apprentices in this cohort you will need to
+                <a href="@Url.Action("Index", "ManageApprentices")">manage your apprentices</a>.
+            </p>
+        }
+        
+        @if (Model.HasOtherCohortsAwaitingApproval)
+        {
+            <a href="@Url.Action("ReadyForReview")">Return to Approve cohorts</a>
+        }
+        else
+        { 
+            <a href="@Url.Action("Cohorts", "Commitment")">Return to your cohorts</a>
         }
 
     </div>


### PR DESCRIPTION
* Call specific cohort approval method

* Adds Transfer flag to CommitmentView
Mapping for same
Unit tests for same

* Adds start date validation rule
Unit tests
Markup changes

* Hacked validation render to show alt detail message

* Fixed broken test

* Removes frameworks from transfer-funded cohorts

* Removes phantom js changelog

* Dpp 1099 remove bulk upload for transfers (#344)

* Adds unit tests and implementation for marking commitment as transfer

* Adds unit tests and implementation for disabling bulk upload page for transfers

* Markup change to hide bulk upload button if a transfer

* Minor change to test to make more readable

* Adds unit test to cover existing code

* Split out a new vm from the original

* Adds new orchestrator method for new viewmodel

* Mocked status calculator to finish test

* Markup and controller changes

* Removed comment