### PR TITLE
DPP-1324 Restrict Extend Edit Ability

### DIFF
--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests/Orchestrators/Commitments/Mappers/WhenMappingApprenticeship.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests/Orchestrators/Commitments/Mappers/WhenMappingApprenticeship.cs
@@ -274,6 +274,18 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests.Orchestrators.Com
             viewModel.HasStarted.Should().BeTrue();
         }
 
+
+        [Test]
+        public void ShouldHaveLockedStatusIfApprovedTransferFundedWithSuccessfulIlrSubmissionAndCourseNotYetStarted()
+        {
+            var apprenticeship = new Apprenticeship { StartDate = _now.AddMonths(3), HasHadDataLockSuccess = true };
+            var commitment = new CommitmentView { TransferSender = new TransferSender { TransferApprovalStatus = TransferApprovalStatus.Approved } };
+
+            var viewModel = _mapper.MapApprenticeship(apprenticeship, commitment);
+
+            viewModel.IsLockedForUpdate.Should().BeTrue();
+        }
+
         [Test]
         public void ShouldHaveTransferFlagSetIfCommitmentHasTransferSender()
         {
@@ -293,7 +305,7 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests.Orchestrators.Com
         [TestCase(false, true, true, TransferApprovalStatus.Rejected)]
         [TestCase(false, false, false, null)]
         [TestCase(false, true, false, null)]
-        public void ThenIsApprovedTransferAndNoSuccessfulIlrSubmissionShouldBeSetCorrectly(bool expected, bool dataLockSuccess, bool transferSender, TransferApprovalStatus? transferApprovalStatus)
+        public void ThenIsUpdateLockedForStartDateAndCourseShouldBeSetCorrectly(bool expected, bool dataLockSuccess, bool transferSender, TransferApprovalStatus? transferApprovalStatus)
         {
             var apprenticeship = new Apprenticeship { HasHadDataLockSuccess = dataLockSuccess };
             var commitment = new CommitmentView();
@@ -305,7 +317,7 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests.Orchestrators.Com
 
             var viewModel = _mapper.MapApprenticeship(apprenticeship, commitment);
 
-            Assert.AreEqual(expected, viewModel.IsApprovedTransferAndNoSuccessfulIlrSubmission);
+            Assert.AreEqual(expected, viewModel.IsUpdateLockedForStartDateAndCourse);
         }
     }
 }

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests/Orchestrators/Commitments/Mappers/WhenMappingApprenticeship.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests/Orchestrators/Commitments/Mappers/WhenMappingApprenticeship.cs
@@ -284,5 +284,28 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests.Orchestrators.Com
 
             viewModel.IsPaidForByTransfer.Should().BeTrue();
         }
+
+        [TestCase(true, false, true, TransferApprovalStatus.Approved)]
+        [TestCase(false, true, true, TransferApprovalStatus.Approved)]
+        [TestCase(false, false, true, TransferApprovalStatus.Pending)]
+        [TestCase(false, true, true, TransferApprovalStatus.Pending)]
+        [TestCase(false, false, true, TransferApprovalStatus.Rejected)]
+        [TestCase(false, true, true, TransferApprovalStatus.Rejected)]
+        [TestCase(false, false, false, null)]
+        [TestCase(false, true, false, null)]
+        public void ThenIsApprovedTransferAndNoSuccessfulIlrSubmissionShouldBeSetCorrectly(bool expected, bool dataLockSuccess, bool transferSender, TransferApprovalStatus? transferApprovalStatus)
+        {
+            var apprenticeship = new Apprenticeship { HasHadDataLockSuccess = dataLockSuccess };
+            var commitment = new CommitmentView();
+
+            if (transferSender)
+            {
+                commitment.TransferSender = new TransferSender { TransferApprovalStatus = transferApprovalStatus };
+            }
+
+            var viewModel = _mapper.MapApprenticeship(apprenticeship, commitment);
+
+            Assert.AreEqual(expected, viewModel.IsApprovedTransferAndNoSuccessfulIlrSubmission);
+        }
     }
 }

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Models/ApprenticeshipViewModel.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Models/ApprenticeshipViewModel.cs
@@ -51,7 +51,7 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.Models
 
         public bool IsLockedForUpdate { get; set; }
         public bool IsPaidForByTransfer { get; set; }
-        public bool IsApprovedTransferAndNoSuccessfulIlrSubmission { get; set; }
+        public bool IsUpdateLockedForStartDateAndCourse { get; set; }
         public string StartDateTransfersMinDateAltDetailMessage { get; set; }
     }
 }

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Models/ApprenticeshipViewModel.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Models/ApprenticeshipViewModel.cs
@@ -51,6 +51,7 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.Models
 
         public bool IsLockedForUpdate { get; set; }
         public bool IsPaidForByTransfer { get; set; }
+        public bool IsApprovedTransferAndNoSuccessfulIlrSubmission { get; set; }
         public string StartDateTransfersMinDateAltDetailMessage { get; set; }
     }
 }

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Orchestrators/Mappers/ApprenticeshipMapper.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Orchestrators/Mappers/ApprenticeshipMapper.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using MediatR;
-
+using SFA.DAS.Commitments.Api.Types;
 using SFA.DAS.Commitments.Api.Types.Apprenticeship;
 using SFA.DAS.Commitments.Api.Types.Apprenticeship.Types;
 using SFA.DAS.Commitments.Api.Types.Commitment;
@@ -73,6 +73,10 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.Orchestrators.Mappers
                 isLockedForUpdate = true;
             }
 
+            var isApprovedTransferAndNoSuccessfulIlrSubmission =
+                commitment.TransferSender?.TransferApprovalStatus == TransferApprovalStatus.Approved
+                && !apprenticeship.HasHadDataLockSuccess;
+
             var dateOfBirth = apprenticeship.DateOfBirth;
             return new ApprenticeshipViewModel
             {
@@ -95,7 +99,8 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.Orchestrators.Mappers
                 EmployerRef = apprenticeship.EmployerRef,
                 HasStarted = !isStartDateInFuture,
                 IsLockedForUpdate = isLockedForUpdate,
-                IsPaidForByTransfer = commitment.TransferSender != null
+                IsPaidForByTransfer = commitment.TransferSender != null,
+                IsApprovedTransferAndNoSuccessfulIlrSubmission = isApprovedTransferAndNoSuccessfulIlrSubmission
             };
         }
 

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/ManageApprentices/Edit.cshtml
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/ManageApprentices/Edit.cshtml
@@ -34,10 +34,11 @@
             @Html.HiddenFor(m => m.AgreementStatus)
             @Html.HiddenFor(m => m.EmployerRef)
             @Html.HiddenFor(m => m.IsLockedForUpdate)
-            
+            @Html.HiddenFor(m => m.IsApprovedTransferAndNoSuccessfulIlrSubmission)
+
             @* next line deliberately commented: add in to support transfer validation rules in manage your apprentices *@
             @*@Html.HiddenFor(m => m.IsPaidForByTransfer)*@
-            
+
             <button type="submit" class="button button-left-align" id="submit-edit-details">Update details</button>
             <a class="link-left-aligned" href="@Url.Action("Details", new { Model.HashedApprenticeshipId })" aria-label="Cancel">Cancel and return</a>
         </form>

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/ManageApprentices/Edit.cshtml
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/ManageApprentices/Edit.cshtml
@@ -34,7 +34,7 @@
             @Html.HiddenFor(m => m.AgreementStatus)
             @Html.HiddenFor(m => m.EmployerRef)
             @Html.HiddenFor(m => m.IsLockedForUpdate)
-            @Html.HiddenFor(m => m.IsApprovedTransferAndNoSuccessfulIlrSubmission)
+            @Html.HiddenFor(m => m.IsUpdateLockedForStartDateAndCourse)
 
             @* next line deliberately commented: add in to support transfer validation rules in manage your apprentices *@
             @*@Html.HiddenFor(m => m.IsPaidForByTransfer)*@

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/ManageApprentices/EditStartedApprenticeship.cshtml
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/ManageApprentices/EditStartedApprenticeship.cshtml
@@ -3,121 +3,122 @@
 <div id="edit-started-apprentice">
     <div class="form-group first-child @Html.AddClassIfPropertyInError(x => x.FirstName, "error")">
 
-        @Html.LabelFor(m => m.FirstName, "First name", new { @class = "form-label form-label-bold" })
-        @Html.ValidationMessageFor(m => m.FirstName, null, new { id = "error-message-" + Html.IdFor(m => m.FirstName) })
-        @Html.TextBoxFor(m => m.FirstName, new { @class = "form-control form-control-3-4" })
-    </div>
-    <div class="form-group @Html.AddClassIfPropertyInError(x => x.LastName, "error")">
-        @Html.LabelFor(m => m.LastName, "Last name", new { @class = "form-label form-label-bold" })
-        @Html.ValidationMessageFor(m => m.LastName, null, new { id = "error-message-" + Html.IdFor(m => m.LastName) })
-        @Html.TextBoxFor(m => m.LastName, new { @class = "form-control form-control-3-4" })
-    </div>
+    @Html.LabelFor(m => m.FirstName, "First name", new { @class = "form-label form-label-bold" })
+    @Html.ValidationMessageFor(m => m.FirstName, null, new { id = "error-message-" + Html.IdFor(m => m.FirstName) })
+    @Html.TextBoxFor(m => m.FirstName, new { @class = "form-control form-control-3-4" })
+</div>
+<div class="form-group @Html.AddClassIfPropertyInError(x => x.LastName, "error")">
+    @Html.LabelFor(m => m.LastName, "Last name", new { @class = "form-label form-label-bold" })
+    @Html.ValidationMessageFor(m => m.LastName, null, new { id = "error-message-" + Html.IdFor(m => m.LastName) })
+    @Html.TextBoxFor(m => m.LastName, new { @class = "form-control form-control-3-4" })
+</div>
 
-    <div class="form-error-group form-group @Html.AddClassIfPropertyInError(x => x.DateOfBirth, "error") ">
+<div class="form-error-group form-group @Html.AddClassIfPropertyInError(x => x.DateOfBirth, "error") ">
+    <hr />
+    <span class="form-label-bold">Date of birth</span>
+    <span class="form-hint">For example, 08 12 2001</span>
+
+    <div class="form-date">
+        @Html.ValidationMessageFor(m => m.DateOfBirth, null, new { id = "error-message-" + Html.IdFor(m => m.DateOfBirth), @class = "error-message" })
+
+        <div class="form-group form-group-day">
+            <label for="@Html.IdFor(m => m.DateOfBirth.Day)">
+                Day
+            </label>
+            @Html.TextBoxFor(m => m.DateOfBirth.Day, new { @class = "form-control length-limit", type = "number", maxlength="2", min="1", max="31", aria_labelledby = Html.IdFor(m => m.DateOfBirth.Day) })
+        </div>
+        <div class="form-group form-group-month">
+            <label for="@Html.IdFor(m => m.DateOfBirth.Month)">
+                Month
+            </label>
+            @Html.TextBoxFor(m => m.DateOfBirth.Month, new { @class = "form-control length-limit", type = "number", maxlength = "2", min = "1", max = "12", aria_labelledby = Html.IdFor(m => m.DateOfBirth.Month) })
+        </div>
+        <div class="form-group form-group-year">
+            <label for="@Html.IdFor(m => m.DateOfBirth.Year)">
+                Year
+            </label>
+            <input aria-labelledby="@Html.IdFor(m => m.DateOfBirth.Year)" class="form-control length-limit" type="number" maxlength="4" min="1900" max="9999" data-val="true" data-val-number="The field Year must be a number." id="@Html.IdFor(m => m.DateOfBirth.Year)" name="DateOfBirth.Year", value="@Model.DateOfBirth.Year">
+        </div>
+    </div>
+</div>
+
+@if (Model.IsLockedForUpdate)
+{
+    <div class="form-group">
+        <hr/>
+        <label class="form-label-bold">
+            Unique learner number
+        </label>
+        <span>
+            @Model.ULN
+        </span>
+    </div>
+    @Html.HiddenFor(m => m.ULN)
+}
+else
+{
+    <div class="form-group @Html.AddClassIfPropertyInError(x => x.ULN, "error")">
         <hr />
-        <span class="form-label-bold">Date of birth</span>
-        <span class="form-hint">For example, 08 12 2001</span>
-
-        <div class="form-date">
-            @Html.ValidationMessageFor(m => m.DateOfBirth, null, new { id = "error-message-" + Html.IdFor(m => m.DateOfBirth), @class = "error-message" })
-
-            <div class="form-group form-group-day">
-                <label for="@Html.IdFor(m => m.DateOfBirth.Day)">
-                    Day
-                </label>
-                @Html.TextBoxFor(m => m.DateOfBirth.Day, new { @class = "form-control length-limit", type = "number", maxlength="2", min="1", max="31", aria_labelledby = Html.IdFor(m => m.DateOfBirth.Day) })
-            </div>
-            <div class="form-group form-group-month">
-                <label for="@Html.IdFor(m => m.DateOfBirth.Month)">
-                    Month
-                </label>
-                @Html.TextBoxFor(m => m.DateOfBirth.Month, new { @class = "form-control length-limit", type = "number", maxlength="2", min="1", max="12", aria_labelledby = Html.IdFor(m => m.DateOfBirth.Month) })
-            </div>
-            <div class="form-group form-group-year">
-                <label for="@Html.IdFor(m => m.DateOfBirth.Year)">
-                    Year
-                </label>
-                <input aria-labelledby="@Html.IdFor(m => m.DateOfBirth.Year)" class="form-control length-limit" data-val="true" data-val-number="The field Year must be a number." id="@Html.IdFor(m => m.DateOfBirth.Year)" name="DateOfBirth.Year" type="number" maxlength="4" min="1900" max="9999" value="@Model.DateOfBirth.Year">
-            </div>
-        </div>
+        <label for="@Html.IdFor(m => m.ULN)">
+            <span class="form-label form-label-bold">Unique learner number</span>
+            @Html.ValidationMessageFor(m => m.ULN, null, new { id = "error-message-" + Html.IdFor(m => m.ULN), @class = "error-message" })
+        </label>
+        @Html.TextBoxFor(m => m.ULN, new { @class = "form-control form-control-3-4", type = "text", aria_labelledby = Html.IdFor(m => m.ULN), maxlength = "10" })
     </div>
-    
-    @if (Model.IsLockedForUpdate)
-    {
-        <div class="form-group">
-            <hr/>
-            <label class="form-label-bold">
-                Unique learner number
-            </label>
-            <span>
-                @Model.ULN
-            </span>
-        </div>
-        @Html.HiddenFor(m => m.ULN)
-    }
-    else
-    {
-        <div class="form-group @Html.AddClassIfPropertyInError(x => x.ULN, "error")">
-            <hr />
-            <label for="@Html.IdFor(m => m.ULN)">
-                <span class="form-label form-label-bold">Unique learner number</span>
-                @Html.ValidationMessageFor(m => m.ULN, null, new { id = "error-message-" + Html.IdFor(m => m.ULN), @class = "error-message" })
-            </label>
-            @Html.TextBoxFor(m => m.ULN, new { @class = "form-control form-control-3-4", type = "text", aria_labelledby = Html.IdFor(m => m.ULN), maxlength = "10" })
-        </div>
-    }
-    
-    @if (Model.IsLockedForUpdate || Model.IsUpdateLockedForStartDateAndCourse)
-    {
-        <div class="form-group">
-            <hr/>
-            <label class="form-label-bold" for="TrainingCode">Apprenticeship training course</label>
-            <span>@Model.TrainingName</span>
-        </div>
-        @Html.HiddenFor(m => m.TrainingCode)
-    }
-    else
-    {
-        <div class="form-group @Html.AddClassIfPropertyInError(x => x.TrainingCode, "error")">
-            <hr />
-            <label class="form-label-bold" for="TrainingCode">Apprenticeship training course</label>
-            <span class="form-hint">Start typing in the name of the course or choose an option from the list</span>
-            @Html.ValidationMessageFor(m => m.TrainingCode, "Choose a training course for this apprentice", new { id = "error-message-" + Html.IdFor(m => m.TrainingCode), @class = "error-message" })
-            <select name="TrainingCode" id="TrainingCode" class="form-control form-control-3-4" aria-label="Apprenticeship training course">
-                <option value="">Please select</option>
-                @foreach (var programme in ViewBag.ApprenticeshipProgrammes)
-                {
-                    <option value="@programme.Id" @if (programme.Id.ToString() == Model.TrainingCode) { @Html.Raw("selected") }>
-                        @programme.Title
-                    </option>
-                }
-            </select>
-        </div>
-    }
-    
-    @if (Model.IsLockedForUpdate || Model.IsUpdateLockedForStartDateAndCourse)
-    {
-        <div class="form-error-group form-group">
-            <hr/>
-            <label class="form-label-bold">Planned training start date</label>
-            <span>@Model.StartDate.DateTime.Value.ToGdsFormatWithoutDay() </span>
-        </div>
+}
 
-        @Html.HiddenFor(m => m.StartDate.Month)
-        @Html.HiddenFor(m => m.StartDate.Year)
-    }
-    @if (Model.IsLockedForUpdate)
-    {
-        <div class="form-error-group form-group">
-            <hr/>
-            <span class="form-label-bold">Planned training finish date</span>
-            <span>@Model.EndDate.DateTime.Value.ToGdsFormatWithoutDay() </span>
-        </div>
+@if (Model.IsLockedForUpdate || Model.IsUpdateLockedForStartDateAndCourse)
+{
+    <div class="form-group">
+        <hr/>
+        <label class="form-label-bold" for="TrainingCode">Apprenticeship training course</label>
+        <span>@Model.TrainingName</span>
+    </div>
+    @Html.HiddenFor(m => m.TrainingCode)
+    @Html.HiddenFor(m => m.TrainingName)
+}
+else
+{
+    <div class="form-group @Html.AddClassIfPropertyInError(x => x.TrainingCode, "error")">
+        <hr />
+        <label class="form-label-bold" for="TrainingCode">Apprenticeship training course</label>
+        <span class="form-hint">Start typing in the name of the course or choose an option from the list</span>
+        @Html.ValidationMessageFor(m => m.TrainingCode, "Choose a training course for this apprentice", new { id = "error-message-" + Html.IdFor(m => m.TrainingCode), @class = "error-message" })
+        <select name="TrainingCode" id="TrainingCode" class="form-control form-control-3-4" aria-label="Apprenticeship training course">
+            <option value="">Please select</option>
+            @foreach (var programme in ViewBag.ApprenticeshipProgrammes)
+            {
+                <option value="@programme.Id" @if (programme.Id.ToString() == Model.TrainingCode) { @Html.Raw("selected") }>
+                    @programme.Title
+                </option>
+            }
+        </select>
+    </div>
+}
 
-        @Html.HiddenFor(m => m.EndDate.Month)
-        @Html.HiddenFor(m => m.EndDate.Year)
-    }
-    else
+@if (Model.IsLockedForUpdate || Model.IsUpdateLockedForStartDateAndCourse)
+{
+    <div class="form-error-group form-group">
+        <hr/>
+        <label class="form-label-bold">Planned training start date</label>
+        <span>@Model.StartDate.DateTime.Value.ToGdsFormatWithoutDay() </span>
+    </div>
+
+    @Html.HiddenFor(m => m.StartDate.Month)
+    @Html.HiddenFor(m => m.StartDate.Year)
+}
+@if (Model.IsLockedForUpdate)
+{
+    <div class="form-error-group form-group">
+        <hr/>
+        <span class="form-label-bold">Planned training finish date</span>
+        <span>@Model.EndDate.DateTime.Value.ToGdsFormatWithoutDay() </span>
+    </div>
+
+    @Html.HiddenFor(m => m.EndDate.Month)
+    @Html.HiddenFor(m => m.EndDate.Year)
+}
+else
     {
         if (!Model.IsUpdateLockedForStartDateAndCourse)
         {

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/ManageApprentices/EditStartedApprenticeship.cshtml
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/ManageApprentices/EditStartedApprenticeship.cshtml
@@ -110,7 +110,7 @@ else
 @if (Model.IsLockedForUpdate)
 {
     <div class="form-error-group form-group">
-        <hr/>
+        @*<hr/>*@
         <span class="form-label-bold">Planned training finish date</span>
         <span>@Model.EndDate.DateTime.Value.ToGdsFormatWithoutDay() </span>
     </div>
@@ -130,11 +130,19 @@ else
                         <span class="form-hint">For example, 09 2017</span>
                     </legend>
                     <div class="form-date">
-                        @Html.ValidationMessageFor(m => m.StartDate, null, new {id = "error-message-" + Html.IdFor(m => m.StartDate), @class = "error-message"})
-                        @Html.ValidationMessage("StartDateOverlap",
-                            "The date overlaps with existing training dates for the same apprentice. " +
-                            "Please check the date - contact the employer for help.",
-                            new {id = "error-message-StartDateOverlap", @class = "error-message"})
+	        	@* hack for alt error message *@
+	                @if (!string.IsNullOrEmpty(Model.StartDateTransfersMinDateAltDetailMessage))
+	                {
+	                    <span id="error-message-StartDate" class="error-message"}>@Model.StartDateTransfersMinDateAltDetailMessage</span>
+	                }
+	                else
+	                {
+	                        @Html.ValidationMessageFor(m => m.StartDate, null, new {id = "error-message-" + Html.IdFor(m => m.StartDate), @class = "error-message"})
+	                        @Html.ValidationMessage("StartDateOverlap",
+	                            "The date overlaps with existing training dates for the same apprentice. " +
+	                            "Please check the date - contact the employer for help.",
+	                            new {id = "error-message-StartDateOverlap", @class = "error-message"})
+			        }
                         <div class="form-group form-group-month">
                             <label for="@Html.IdFor(m => m.StartDate.Month)">
                                 <span class="form-label-bold">Month</span>
@@ -151,34 +159,35 @@ else
                 </fieldset>
             </div>
         }
-        <div class="form-error-group form-group @Html.AddClassIfPropertyInError(x => x.EndDate, "error") @Html.AddClassIfPropertyInError("EndDateOverlap", "error")">
-            <fieldset>
-                <legend>
-                    <span class="form-label-bold">Projected finish date</span>
-                    <span class="form-hint">For example, 02 2019</span>
-                </legend>
-                <div class="form-date">
-                    @Html.ValidationMessageFor(m => m.EndDate, null, new { id = "error-message-" + Html.IdFor(m => m.EndDate), @class = "error-message" })
-                    @Html.ValidationMessage("EndDateOverlap",
-                    "The date overlaps with existing training dates for the same apprentice. " +
-                        "Please check the date - contact the employer for help.",
-                    new { id = "error-message-EndDateOverlap", @class = "error-message" })
-                    <div class="form-group form-group-month">
-                        <label for="@Html.IdFor(m => m.EndDate.Month)">
-                            <span class="form-label-bold">Month</span>
-                        </label>
-                        @Html.TextBoxFor(m => m.EndDate.Month, new { @class = "form-control length-limit", type = "number", maxlength = "2", min = "1", max = "12", aria_labelledby = Html.IdFor(m => m.EndDate.Month) })
-                    </div>
+            <div class="form-error-group form-group @Html.AddClassIfPropertyInError(x => x.EndDate, "error") @Html.AddClassIfPropertyInError("EndDateOverlap", "error")">
+                @*<hr />*@
+                <fieldset>
+                    <legend>
+                        <span class="form-label-bold">Projected finish date</span>
+                        <span class="form-hint">For example, 02 2019</span>
+                    </legend>
+                    <div class="form-date">
+                        @Html.ValidationMessageFor(m => m.EndDate, null, new { id = "error-message-" + Html.IdFor(m => m.EndDate), @class = "error-message" })
+                        @Html.ValidationMessage("EndDateOverlap",
+                 "The date overlaps with existing training dates for the same apprentice. " +
+                     "Please check the date - contact the employer for help.",
+                 new { id = "error-message-EndDateOverlap", @class = "error-message" })
+                        <div class="form-group form-group-month">
+                            <label for="@Html.IdFor(m => m.EndDate.Month)">
+                                <span class="form-label-bold">Month</span>
+                            </label>
+                            @Html.TextBoxFor(m => m.EndDate.Month, new { @class = "form-control length-limit", type = "number", maxlength = "2", min = "1", max = "12", aria_labelledby = Html.IdFor(m => m.EndDate.Month) })
+                        </div>
 
-                    <div class="form-group form-group-month">
-                        <label for="@Html.IdFor(m => m.EndDate.Year)">
-                            <span class="form-label-bold">Year</span>
-                        </label>
-                        <input aria-labelledby="EndDate" class="form-control length-limit" data-val="true" data-val-number="The field Year must be a number." id="@Html.IdFor(m => m.EndDate.Year)" name="@Html.NameFor(m => m.EndDate.Year)" type="number" maxlength="4" min="1900" max="9999" value="@Model.EndDate.Year">
+                        <div class="form-group form-group-month">
+                            <label for="@Html.IdFor(m => m.EndDate.Year)">
+                                <span class="form-label-bold">Year</span>
+                            </label>
+                            <input aria-labelledby="EndDate" class="form-control length-limit" data-val="true" data-val-number="The field Year must be a number." id="@Html.IdFor(m => m.EndDate.Year)" name="@Html.NameFor(m => m.EndDate.Year)" type="number" maxlength="4" min="1900" max="9999" value="@Model.EndDate.Year">
+                        </div>
                     </div>
-                </div>
-            </fieldset>
-        </div>
+                </fieldset>
+            </div>
     }
   
     <div class="form-group @Html.AddClassIfPropertyInError(x => x.Cost, "error")">
@@ -197,7 +206,6 @@ else
                     submission first. Once you've submitted your updated ILR, you'll see an option to update the price in the apprenticeship service.
                 </div>
             </div>
-            <hr/>
         }
         else
         {
@@ -208,23 +216,27 @@ else
             </label>
             <span class="heading-small">£ </span>
             @Html.TextBoxFor(m => m.Cost, new { @class = "form-control form-control-3-4", type = "text", aria_labelledby = Html.IdFor(m => m.Cost), maxlength = "7" })
-            <hr />
         }
     </div>
 
     <div class="form-group last-child @Html.AddClassIfPropertyInError(x => x.ProviderRef, "error")">
-
+	<hr />
         @Html.LabelFor(m => m.ProviderRef, "Reference (optional)", new { @class = "form-label-bold" })
         <span class="form-hint">Add a reference, such as employee number or location - this won’t be seen by the employer</span>
         @Html.ValidationMessageFor(m => m.ProviderRef, null, new { id = "error-message-" + Html.IdFor(m => m.ProviderRef) })
         @Html.TextBoxFor(m => m.ProviderRef, new { @class = "form-control form-control-3-4" })
+	@* do we want this? does it work? *@
+	<p id="charCount-noJS">Enter up to a maximum of 20 characters</p>
+    	<p id="charCount" style="display:none;"><span name="countchars" id="countchars"></span> characters remaining</p>
     </div>
 </div>
 
+@* do we need these? just hasstarted? across both partials? *@
 
-@Html.HiddenFor(m => m.HasStarted)
+@* @Html.HiddenFor(m => m.HasStarted)
 @Html.HiddenFor(m => m.TrainingType)
 @Html.HiddenFor(m => m.TrainingName)
+ *@
 
 @* next line deliberately commented: add in to support transfer validation rules in manage your apprentices *@
 @*@Html.HiddenFor(m => m.IsPaidForByTransfer)*@

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/ManageApprentices/EditStartedApprenticeship.cshtml
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/ManageApprentices/EditStartedApprenticeship.cshtml
@@ -225,18 +225,10 @@ else
         <span class="form-hint">Add a reference, such as employee number or location - this won’t be seen by the employer</span>
         @Html.ValidationMessageFor(m => m.ProviderRef, null, new { id = "error-message-" + Html.IdFor(m => m.ProviderRef) })
         @Html.TextBoxFor(m => m.ProviderRef, new { @class = "form-control form-control-3-4" })
-	@* do we want this? does it work? *@
 	<p id="charCount-noJS">Enter up to a maximum of 20 characters</p>
     	<p id="charCount" style="display:none;"><span name="countchars" id="countchars"></span> characters remaining</p>
     </div>
 </div>
-
-@* do we need these? just hasstarted? across both partials? *@
-
-@* @Html.HiddenFor(m => m.HasStarted)
-@Html.HiddenFor(m => m.TrainingType)
-@Html.HiddenFor(m => m.TrainingName)
- *@
 
 @* next line deliberately commented: add in to support transfer validation rules in manage your apprentices *@
 @*@Html.HiddenFor(m => m.IsPaidForByTransfer)*@

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/ManageApprentices/EditStartedApprenticeship.cshtml
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/ManageApprentices/EditStartedApprenticeship.cshtml
@@ -67,7 +67,7 @@
         </div>
     }
     
-    @if (Model.IsLockedForUpdate || Model.IsApprovedTransferAndNoSuccessfulIlrSubmission)
+    @if (Model.IsLockedForUpdate || Model.IsUpdateLockedForStartDateAndCourse)
     {
         <div class="form-group">
             <hr/>
@@ -95,7 +95,7 @@
         </div>
     }
     
-    @if (Model.IsLockedForUpdate || Model.IsApprovedTransferAndNoSuccessfulIlrSubmission)
+    @if (Model.IsLockedForUpdate || Model.IsUpdateLockedForStartDateAndCourse)
     {
         <div class="form-error-group form-group">
             <hr/>
@@ -119,7 +119,7 @@
     }
     else
     {
-        if (!Model.IsApprovedTransferAndNoSuccessfulIlrSubmission)
+        if (!Model.IsUpdateLockedForStartDateAndCourse)
         {
             <div class="form-error-group form-group first-child @Html.AddClassIfPropertyInError(x => x.StartDate, "error") @Html.AddClassIfPropertyInError(x => x.StartDate, "error") @Html.AddClassIfPropertyInError("StartDateOverlap", "error")">
                 <hr/>

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/ManageApprentices/EditStartedApprenticeship.cshtml
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/ManageApprentices/EditStartedApprenticeship.cshtml
@@ -67,7 +67,7 @@
         </div>
     }
     
-    @if (Model.IsLockedForUpdate)
+    @if (Model.IsLockedForUpdate || Model.IsApprovedTransferAndNoSuccessfulIlrSubmission)
     {
         <div class="form-group">
             <hr/>
@@ -95,58 +95,61 @@
         </div>
     }
     
-    @if (Model.IsLockedForUpdate)
+    @if (Model.IsLockedForUpdate || Model.IsApprovedTransferAndNoSuccessfulIlrSubmission)
     {
         <div class="form-error-group form-group">
             <hr/>
             <label class="form-label-bold">Planned training start date</label>
             <span>@Model.StartDate.DateTime.Value.ToGdsFormatWithoutDay() </span>
-
         </div>
 
+        @Html.HiddenFor(m => m.StartDate.Month)
+        @Html.HiddenFor(m => m.StartDate.Year)
+    }
+    @if (Model.IsLockedForUpdate)
+    {
         <div class="form-error-group form-group">
             <hr/>
             <span class="form-label-bold">Planned training finish date</span>
             <span>@Model.EndDate.DateTime.Value.ToGdsFormatWithoutDay() </span>
         </div>
 
-        @Html.HiddenFor(m => m.StartDate.Month)
-        @Html.HiddenFor(m => m.StartDate.Year)
-
         @Html.HiddenFor(m => m.EndDate.Month)
         @Html.HiddenFor(m => m.EndDate.Year)
     }
     else
     {
-        <div class="form-error-group form-group first-child @Html.AddClassIfPropertyInError(x => x.StartDate, "error") @Html.AddClassIfPropertyInError(x => x.StartDate, "error") @Html.AddClassIfPropertyInError("StartDateOverlap", "error")">
-            <hr />
-            <fieldset>
-                <legend>
-                    <span class="form-label-bold">Planned training start date</span>
-                    <span class="form-hint">For example, 09 2017</span>
-                </legend>
-                <div class="form-date">
-                    @Html.ValidationMessageFor(m => m.StartDate, null, new { id = "error-message-" + Html.IdFor(m => m.StartDate), @class = "error-message" })
-                    @Html.ValidationMessage("StartDateOverlap",
-                        "The date overlaps with existing training dates for the same apprentice. " +
-                        "Please check the date - contact the employer for help.",
-                        new { id = "error-message-StartDateOverlap", @class = "error-message" })
-                    <div class="form-group form-group-month">
-                        <label for="@Html.IdFor(m => m.StartDate.Month)">
-                            <span class="form-label-bold">Month</span>
-                        </label>
-                        @Html.TextBoxFor(m => m.StartDate.Month, new { @class = "form-control length-limit", type = "number", maxlength = "2", min = "1", max = "12", aria_labelledby = Html.IdFor(m => m.StartDate.Month) })
+        if (!Model.IsApprovedTransferAndNoSuccessfulIlrSubmission)
+        {
+            <div class="form-error-group form-group first-child @Html.AddClassIfPropertyInError(x => x.StartDate, "error") @Html.AddClassIfPropertyInError(x => x.StartDate, "error") @Html.AddClassIfPropertyInError("StartDateOverlap", "error")">
+                <hr/>
+                <fieldset>
+                    <legend>
+                        <span class="form-label-bold">Planned training start date</span>
+                        <span class="form-hint">For example, 09 2017</span>
+                    </legend>
+                    <div class="form-date">
+                        @Html.ValidationMessageFor(m => m.StartDate, null, new {id = "error-message-" + Html.IdFor(m => m.StartDate), @class = "error-message"})
+                        @Html.ValidationMessage("StartDateOverlap",
+                            "The date overlaps with existing training dates for the same apprentice. " +
+                            "Please check the date - contact the employer for help.",
+                            new {id = "error-message-StartDateOverlap", @class = "error-message"})
+                        <div class="form-group form-group-month">
+                            <label for="@Html.IdFor(m => m.StartDate.Month)">
+                                <span class="form-label-bold">Month</span>
+                            </label>
+                            @Html.TextBoxFor(m => m.StartDate.Month, new {@class = "form-control length-limit", type = "number", maxlength = "2", min = "1", max = "12", aria_labelledby = Html.IdFor(m => m.StartDate.Month)})
+                        </div>
+                        <div class="form-group form-group-month">
+                            <label for="@Html.IdFor(m => m.StartDate)">
+                                <span class="form-label-bold">Year</span>
+                            </label>
+                            <input aria-labelledby="StartDate" class="form-control length-limit" maxlength="4" min="1900" max="9999" data-val="true" data-val-number="The field Year must be a number." id="@Html.IdFor(m => m.StartDate.Year)" name="@Html.NameFor(m => m.StartDate.Year)" type="number" value="@Model.StartDate.Year">
+                        </div>
                     </div>
-                    <div class="form-group form-group-month">
-                        <label for="@Html.IdFor(m => m.StartDate)">
-                            <span class="form-label-bold">Year</span>
-                        </label>
-                        <input aria-labelledby="StartDate" class="form-control length-limit" maxlength="4" min="1900" max="9999" data-val="true" data-val-number="The field Year must be a number." id="@Html.IdFor(m => m.StartDate.Year)" name="@Html.NameFor(m => m.StartDate.Year)" type="number" value="@Model.StartDate.Year">
-                    </div>
-                </div>
-            </fieldset>
-        </div>
-
+                </fieldset>
+            </div>
+        }
         <div class="form-error-group form-group @Html.AddClassIfPropertyInError(x => x.EndDate, "error") @Html.AddClassIfPropertyInError("EndDateOverlap", "error")">
             <fieldset>
                 <legend>

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/Shared/EditApprenticeship.cshtml
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/Shared/EditApprenticeship.cshtml
@@ -54,7 +54,7 @@
 <div class="form-group @Html.AddClassIfPropertyInError(x => x.TrainingCode, "error")">
     <hr />
     <label class="form-label-bold" for="TrainingCode">Apprenticeship training course</label>
-    @if (Model.IsApprovedTransferAndNoSuccessfulIlrSubmission)
+    @if (Model.IsUpdateLockedForStartDateAndCourse)
     {
         <span id="TrainingCode">@Model.TrainingName</span>
 
@@ -84,7 +84,7 @@
 <div class="form-error-group form-group @Html.AddClassIfPropertyInError(x => x.StartDate, "error") @Html.AddClassIfPropertyInError(x => x.StartDate, "error") @Html.AddClassIfPropertyInError("StartDateOverlap", "error")">
     <hr />
     <fieldset>
-        @if (Model.IsApprovedTransferAndNoSuccessfulIlrSubmission)
+        @if (Model.IsUpdateLockedForStartDateAndCourse)
         {
             <legend>
                 <span class="form-label-bold">Planned training start date</span>

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/Shared/EditApprenticeship.cshtml
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/Shared/EditApprenticeship.cshtml
@@ -54,53 +54,82 @@
 <div class="form-group @Html.AddClassIfPropertyInError(x => x.TrainingCode, "error")">
     <hr />
     <label class="form-label-bold" for="TrainingCode">Apprenticeship training course</label>
-    <span class="form-hint">Start typing in the name of the course or choose an option from the list</span>
-    @Html.ValidationMessageFor(m => m.TrainingCode, "Choose a training course for this apprentice", new { id = "error-message-" + Html.IdFor(m => m.TrainingCode), @class = "error-message" })
-    <select name="TrainingCode" id="TrainingCode" class="form-control form-control-3-4" aria-label="Apprenticeship training course">
-        <option value="">Please select</option>
-        @foreach (var programme in ViewBag.ApprenticeshipProgrammes)
+    @if (Model.IsApprovedTransferAndNoSuccessfulIlrSubmission)
+    {
+        <span id="TrainingCode">@Model.TrainingName</span>
+
+        @Html.Hidden("TrainingCode", Model.TrainingCode)
+        @Html.Hidden("TrainingName", Model.TrainingName)
+    }
+    else
+    {
+        <span class="form-hint">Start typing in the name of the course or choose an option from the list</span>
+        @Html.ValidationMessageFor(m => m.TrainingCode, "Choose a training course for this apprentice", new {id = "error-message-" + Html.IdFor(m => m.TrainingCode), @class = "error-message"})
+        <select name="TrainingCode" id="TrainingCode" class="form-control form-control-3-4" aria-label="Apprenticeship training course">
+            <option value="">Please select</option>
+            @foreach (var programme in ViewBag.ApprenticeshipProgrammes)
             {
-            <option value="@programme.Id" @if (programme.Id.ToString() == Model.TrainingCode) { @Html.Raw("selected")} >
-                @programme.Title
-            </option>
-        }
-    </select>
+                <option value="@programme.Id"
+                        @if (programme.Id.ToString() == Model.TrainingCode)
+                        {
+                            @Html.Raw("selected")
+                        }>
+                    @programme.Title
+                </option>
+            }
+        </select>
+    }
 </div>
 
 <div class="form-error-group form-group @Html.AddClassIfPropertyInError(x => x.StartDate, "error") @Html.AddClassIfPropertyInError(x => x.StartDate, "error") @Html.AddClassIfPropertyInError("StartDateOverlap", "error")">
     <hr />
     <fieldset>
-        <legend>
-            <span class="form-label-bold">Planned training start date</span>
-            <span class="form-hint">For example, 09 2017</span>
-        </legend>
-        <div class="form-date">
-            @* hack for alt error message *@
-            @if (!string.IsNullOrEmpty(Model.StartDateTransfersMinDateAltDetailMessage))
-            {
-                <span id="error-message-StartDate" class="error-message"}>@Model.StartDateTransfersMinDateAltDetailMessage</span>
-            }
-            else
-            {
-                @Html.ValidationMessageFor(m => m.StartDate, null, new {id = "error-message-" + Html.IdFor(m => m.StartDate), @class = "error-message"})
-                @Html.ValidationMessage("StartDateOverlap",
-                    "The date overlaps with existing training dates for the same apprentice. " +
-                    "Please check the date - contact the employer for help.",
-                    new {id = "error-message-StartDateOverlap", @class = "error-message"})
-            }
-            <div class="form-group form-group-month">
-                <label for="@Html.IdFor(m => m.StartDate.Month)">
-                    <span class="form-label-bold">Month</span>
-                </label>
-                @Html.TextBoxFor(m => m.StartDate.Month, new {@class = "form-control length-limit", type = "number", maxlength = "2", min = "1", max = "12", aria_labelledby = Html.IdFor(m => m.StartDate.Month)})
+        @if (Model.IsApprovedTransferAndNoSuccessfulIlrSubmission)
+        {
+            <legend>
+                <span class="form-label-bold">Planned training start date</span>
+            </legend>
+
+            <span>@Model.StartDate.DateTime.Value.ToGdsFormatWithoutDay()</span>
+
+            @Html.Hidden("StartDate.Month", Model.StartDate.Month)
+            @Html.Hidden("StartDate.Year", Model.StartDate.Year)
+        }
+        else
+        {
+            <legend>
+                <span class="form-label-bold">Planned training start date</span>
+                <span class="form-hint">For example, 09 2017</span>
+            </legend>
+
+            <div class="form-date">
+                @* hack for alt error message *@
+                @if (!string.IsNullOrEmpty(Model.StartDateTransfersMinDateAltDetailMessage))
+                {
+                    <span id="error-message-StartDate" class="error-message"}>@Model.StartDateTransfersMinDateAltDetailMessage</span>
+                }
+                else
+                {
+                    @Html.ValidationMessageFor(m => m.StartDate, null, new {id = "error-message-" + Html.IdFor(m => m.StartDate), @class = "error-message"})
+                    @Html.ValidationMessage("StartDateOverlap",
+                        "The date overlaps with existing training dates for the same apprentice. " +
+                        "Please check the date - contact the employer for help.",
+                        new {id = "error-message-StartDateOverlap", @class = "error-message"})
+                }
+                <div class="form-group form-group-month">
+                    <label for="@Html.IdFor(m => m.StartDate.Month)">
+                        <span class="form-label-bold">Month</span>
+                    </label>
+                    @Html.TextBoxFor(m => m.StartDate.Month, new {@class = "form-control length-limit", type = "number", maxlength = "2", min = "1", max = "12", aria_labelledby = Html.IdFor(m => m.StartDate.Month)})
+                </div>
+                <div class="form-group form-group-month">
+                    <label for="@Html.IdFor(m => m.StartDate)">
+                        <span class="form-label-bold">Year</span>
+                    </label>
+                    <input aria-labelledby="StartDate" class="form-control length-limit" maxlength="4" min="1900" max="9999" data-val="true" data-val-number="The field Year must be a number." id="@Html.IdFor(m => m.StartDate.Year)" name="@Html.NameFor(m => m.StartDate.Year)" type="number" value="@Model.StartDate.Year">
+                </div>
             </div>
-            <div class="form-group form-group-month">
-                <label for="@Html.IdFor(m => m.StartDate)">
-                    <span class="form-label-bold">Year</span>
-                </label>
-                <input aria-labelledby="StartDate" class="form-control length-limit" maxlength="4" min="1900" max="9999" data-val="true" data-val-number="The field Year must be a number." id="@Html.IdFor(m => m.StartDate.Year)" name="@Html.NameFor(m => m.StartDate.Year)" type="number" value="@Model.StartDate.Year">
-            </div>
-        </div>
+        }
     </fieldset>
 </div>
 

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/Shared/EditApprenticeship.cshtml
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/Shared/EditApprenticeship.cshtml
@@ -96,97 +96,128 @@ else
     </div>
 }
 
-<div class="form-error-group form-group @Html.AddClassIfPropertyInError(x => x.StartDate, "error") @Html.AddClassIfPropertyInError(x => x.StartDate, "error") @Html.AddClassIfPropertyInError("StartDateOverlap", "error")">
-    <hr />
-    <fieldset>
-        @if (Model.IsUpdateLockedForStartDateAndCourse)
+@if (Model.IsLockedForUpdate || Model.IsUpdateLockedForStartDateAndCourse)
+{
+    <div class="form-error-group form-group">
+        <hr/>
+        <label class="form-label-bold">Planned training start date</label>
+        <span>@Model.StartDate.DateTime.Value.ToGdsFormatWithoutDay() </span>
+    </div>
+
+    @Html.HiddenFor(m => m.StartDate.Month)
+    @Html.HiddenFor(m => m.StartDate.Year)
+}
+@if (Model.IsLockedForUpdate)
+{
+    <div class="form-error-group form-group">
+        @*<hr/>*@
+        <span class="form-label-bold">Planned training finish date</span>
+        <span>@Model.EndDate.DateTime.Value.ToGdsFormatWithoutDay() </span>
+    </div>
+
+    @Html.HiddenFor(m => m.EndDate.Month)
+    @Html.HiddenFor(m => m.EndDate.Year)
+}
+else
+    {
+        if (!Model.IsUpdateLockedForStartDateAndCourse)
         {
-            <legend>
-                <span class="form-label-bold">Planned training start date</span>
-            </legend>
-
-            <span>@Model.StartDate.DateTime.Value.ToGdsFormatWithoutDay()</span>
-
-            @Html.HiddenFor(m => m.StartDate.Month)
-            @Html.HiddenFor(m => m.StartDate.Year)
-        }
-        else
-        {
-            <legend>
-                <span class="form-label-bold">Planned training start date</span>
-                <span class="form-hint">For example, 09 2017</span>
-            </legend>
-
-            <div class="form-date">
-                @* hack for alt error message *@
-                @if (!string.IsNullOrEmpty(Model.StartDateTransfersMinDateAltDetailMessage))
-                {
-                    <span id="error-message-StartDate" class="error-message"}>@Model.StartDateTransfersMinDateAltDetailMessage</span>
-                }
-                else
-                {
-                    @Html.ValidationMessageFor(m => m.StartDate, null, new {id = "error-message-" + Html.IdFor(m => m.StartDate), @class = "error-message"})
-                    @Html.ValidationMessage("StartDateOverlap",
-                        "The date overlaps with existing training dates for the same apprentice. " +
-                        "Please check the date - contact the employer for help.",
-                        new {id = "error-message-StartDateOverlap", @class = "error-message"})
-                }
-                <div class="form-group form-group-month">
-                    <label for="@Html.IdFor(m => m.StartDate.Month)">
-                        <span class="form-label-bold">Month</span>
-                    </label>
-                    @Html.TextBoxFor(m => m.StartDate.Month, new {@class = "form-control length-limit", type = "number", maxlength = "2", min = "1", max = "12", aria_labelledby = Html.IdFor(m => m.StartDate.Month)})
-                </div>
-                <div class="form-group form-group-month">
-                    <label for="@Html.IdFor(m => m.StartDate)">
-                        <span class="form-label-bold">Year</span>
-                    </label>
-                    <input aria-labelledby="StartDate" class="form-control length-limit" maxlength="4" min="1900" max="9999" data-val="true" data-val-number="The field Year must be a number." id="@Html.IdFor(m => m.StartDate.Year)" name="@Html.NameFor(m => m.StartDate.Year)" type="number" value="@Model.StartDate.Year">
-                </div>
+            <div class="form-error-group form-group @Html.AddClassIfPropertyInError(x => x.StartDate, "error") @Html.AddClassIfPropertyInError(x => x.StartDate, "error") @Html.AddClassIfPropertyInError("StartDateOverlap", "error")">
+                <hr/>
+                <fieldset>
+                    <legend>
+                        <span class="form-label-bold">Planned training start date</span>
+                        <span class="form-hint">For example, 09 2017</span>
+                    </legend>
+                    <div class="form-date">
+	        	@* hack for alt error message *@
+	                @if (!string.IsNullOrEmpty(Model.StartDateTransfersMinDateAltDetailMessage))
+	                {
+	                    <span id="error-message-StartDate" class="error-message"}>@Model.StartDateTransfersMinDateAltDetailMessage</span>
+	                }
+	                else
+	                {
+	                        @Html.ValidationMessageFor(m => m.StartDate, null, new {id = "error-message-" + Html.IdFor(m => m.StartDate), @class = "error-message"})
+	                        @Html.ValidationMessage("StartDateOverlap",
+	                            "The date overlaps with existing training dates for the same apprentice. " +
+	                            "Please check the date - contact the employer for help.",
+	                            new {id = "error-message-StartDateOverlap", @class = "error-message"})
+			        }
+                        <div class="form-group form-group-month">
+                            <label for="@Html.IdFor(m => m.StartDate.Month)">
+                                <span class="form-label-bold">Month</span>
+                            </label>
+                            @Html.TextBoxFor(m => m.StartDate.Month, new {@class = "form-control length-limit", type = "number", maxlength = "2", min = "1", max = "12", aria_labelledby = Html.IdFor(m => m.StartDate.Month)})
+                        </div>
+                        <div class="form-group form-group-month">
+                            <label for="@Html.IdFor(m => m.StartDate)">
+                                <span class="form-label-bold">Year</span>
+                            </label>
+                            <input aria-labelledby="StartDate" class="form-control length-limit" maxlength="4" min="1900" max="9999" data-val="true" data-val-number="The field Year must be a number." id="@Html.IdFor(m => m.StartDate.Year)" name="@Html.NameFor(m => m.StartDate.Year)" type="number" value="@Model.StartDate.Year">
+                        </div>
+                    </div>
+                </fieldset>
             </div>
         }
-    </fieldset>
-</div>
-
-<div class="form-error-group form-group @Html.AddClassIfPropertyInError(x => x.EndDate, "error") @Html.AddClassIfPropertyInError("EndDateOverlap", "error")">
-    <fieldset>
-        <legend>
-            <span class="form-label-bold">Projected finish date</span>
-            <span class="form-hint">For example, 02 2019</span>
-        </legend>
-        <div class="form-date">
-            @Html.ValidationMessageFor(m => m.EndDate, null, new { id = "error-message-" + Html.IdFor(m => m.EndDate), @class = "error-message" })
-            @Html.ValidationMessage("EndDateOverlap",
+        <div class="form-error-group form-group @Html.AddClassIfPropertyInError(x => x.EndDate, "error") @Html.AddClassIfPropertyInError("EndDateOverlap", "error")">
+            @*<hr/>*@
+            <fieldset>
+                <legend>
+                    <span class="form-label-bold">Projected finish date</span>
+                    <span class="form-hint">For example, 02 2019</span>
+                </legend>
+                <div class="form-date">
+                    @Html.ValidationMessageFor(m => m.EndDate, null, new { id = "error-message-" + Html.IdFor(m => m.EndDate), @class = "error-message" })
+                    @Html.ValidationMessage("EndDateOverlap",
                     "The date overlaps with existing training dates for the same apprentice. " +
                         "Please check the date - contact the employer for help.",
                     new { id = "error-message-EndDateOverlap", @class = "error-message" })
-            <div class="form-group form-group-month">
-                <label for="@Html.IdFor(m => m.EndDate.Month)">
-                    <span class="form-label-bold">Month</span>
-                </label>
-                @Html.TextBoxFor(m => m.EndDate.Month, new { @class = "form-control length-limit", type = "number", maxlength="2", min="1", max="12", aria_labelledby = Html.IdFor(m => m.EndDate.Month) })
-            </div>
+                    <div class="form-group form-group-month">
+                        <label for="@Html.IdFor(m => m.EndDate.Month)">
+                            <span class="form-label-bold">Month</span>
+                        </label>
+                        @Html.TextBoxFor(m => m.EndDate.Month, new { @class = "form-control length-limit", type = "number", maxlength = "2", min = "1", max = "12", aria_labelledby = Html.IdFor(m => m.EndDate.Month) })
+                    </div>
 
-            <div class="form-group form-group-month">
-                <label for="@Html.IdFor(m => m.EndDate.Year)">
-                    <span class="form-label-bold">Year</span>
-                </label>
-                <input aria-labelledby="EndDate" class="form-control length-limit" data-val="true" data-val-number="The field Year must be a number." id="@Html.IdFor(m => m.EndDate.Year)" name="@Html.NameFor(m => m.EndDate.Year)" type="number" maxlength="4" min="1900" max="9999" value="@Model.EndDate.Year">
-            </div>
+                    <div class="form-group form-group-month">
+                        <label for="@Html.IdFor(m => m.EndDate.Year)">
+                            <span class="form-label-bold">Year</span>
+                        </label>
+                        <input aria-labelledby="EndDate" class="form-control length-limit" data-val="true" data-val-number="The field Year must be a number." id="@Html.IdFor(m => m.EndDate.Year)" name="@Html.NameFor(m => m.EndDate.Year)" type="number" maxlength="4" min="1900" max="9999" value="@Model.EndDate.Year">
+                    </div>
+                </div>
+            </fieldset>
         </div>
-    </fieldset>
-</div>
-
-<div class="form-group @Html.AddClassIfPropertyInError(x => x.Cost, "error")">
-    <hr />
-    <label for="@Html.IdFor(m => m.Cost)">
-        <span class="form-label-bold">Total agreed apprenticeship price (excluding VAT)</span>
-        <span class="form-hint">Enter the price, including any end-point assessment costs, in whole pounds. For example, for £1,500 enter 1500.</span>
-        @Html.ValidationMessageFor(m => m.Cost, null, new { id = "error-message-" + Html.IdFor(m => m.Cost), @class = "error-message" })
-    </label>
-    <span class="heading-small">£ </span>@Html.TextBoxFor(m => m.Cost, new { @class = "form-control form-control-3-4", type = "text", aria_labelledby = Html.IdFor(m => m.Cost), maxlength = "7" })
-   
-</div>
+    }
+  
+    <div class="form-group @Html.AddClassIfPropertyInError(x => x.Cost, "error")">
+        <hr />
+        @if (Model.IsLockedForUpdate)
+        {
+            <label for="@Html.IdFor(m => m.Cost)">
+                <span class="form-label-bold">Total agreed apprenticeship price (excluding VAT)</span>
+            </label>
+            <span class="heading-small">£ </span>
+            <span>@Model.Cost</span>
+            @Html.HiddenFor(m => m.Cost)
+            <div class="approve-alert">
+                <div class="panel panel-border-wide alert-blue">
+                    If you want to change the total agreed apprenticeship price, you'll need to make the price change in your ILR
+                    submission first. Once you've submitted your updated ILR, you'll see an option to update the price in the apprenticeship service.
+                </div>
+            </div>
+        }
+        else
+        {
+            <label for="@Html.IdFor(m => m.Cost)">
+                <span class="form-label-bold">Total agreed apprenticeship price (excluding VAT)</span>
+                <span class="form-hint">Enter the price, including any end-point assessment costs, in whole pounds. For example, for £1,500 enter 1500.</span>
+                @Html.ValidationMessageFor(m => m.Cost, null, new { id = "error-message-" + Html.IdFor(m => m.Cost), @class = "error-message" })
+            </label>
+            <span class="heading-small">£ </span>
+            @Html.TextBoxFor(m => m.Cost, new { @class = "form-control form-control-3-4", type = "text", aria_labelledby = Html.IdFor(m => m.Cost), maxlength = "7" })
+        }
+    </div>
 
 <div class="form-group @Html.AddClassIfPropertyInError(x => x.ProviderRef, "error")">
     <hr />

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/Shared/EditApprenticeship.cshtml
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/Shared/EditApprenticeship.cshtml
@@ -42,44 +42,59 @@
     </div>
 </div>
 
-<div class="form-group @Html.AddClassIfPropertyInError(x => x.ULN, "error")">
-    <hr />
-    <label for="@Html.IdFor(m => m.ULN)">
-        <span class="form-label form-label-bold">Unique learner number</span>
-        @Html.ValidationMessageFor(m => m.ULN, null, new { id = "error-message-" + Html.IdFor(m => m.ULN), @class = "error-message" })
-    </label>
-    @Html.TextBoxFor(m => m.ULN, new { @class = "form-control form-control-3-4", type = "text", aria_labelledby = Html.IdFor(m => m.ULN), maxlength = "10" })
-</div>
+@if (Model.IsLockedForUpdate)
+{
+    <div class="form-group">
+        <hr/>
+        <label class="form-label-bold">
+            Unique learner number
+        </label>
+        <span>
+            @Model.ULN
+        </span>
+    </div>
+    @Html.HiddenFor(m => m.ULN)
+}
+else
+{
+    <div class="form-group @Html.AddClassIfPropertyInError(x => x.ULN, "error")">
+        <hr />
+        <label for="@Html.IdFor(m => m.ULN)">
+            <span class="form-label form-label-bold">Unique learner number</span>
+            @Html.ValidationMessageFor(m => m.ULN, null, new { id = "error-message-" + Html.IdFor(m => m.ULN), @class = "error-message" })
+        </label>
+        @Html.TextBoxFor(m => m.ULN, new { @class = "form-control form-control-3-4", type = "text", aria_labelledby = Html.IdFor(m => m.ULN), maxlength = "10" })
+    </div>
+}
 
-<div class="form-group @Html.AddClassIfPropertyInError(x => x.TrainingCode, "error")">
-    <hr />
-    <label class="form-label-bold" for="TrainingCode">Apprenticeship training course</label>
-    @if (Model.IsUpdateLockedForStartDateAndCourse)
-    {
+@if (Model.IsLockedForUpdate || Model.IsUpdateLockedForStartDateAndCourse)
+{
+    <div class="form-group">
+        <hr/>
+        <label class="form-label-bold" for="TrainingCode">Apprenticeship training course</label>
         <span id="TrainingCode">@Model.TrainingName</span>
-
-        @Html.Hidden("TrainingCode", Model.TrainingCode)
-        @Html.Hidden("TrainingName", Model.TrainingName)
-    }
-    else
-    {
+    </div>
+    @Html.HiddenFor(m => m.TrainingCode)
+    @Html.HiddenFor(m => m.TrainingName)
+}
+else
+{
+    <div class="form-group @Html.AddClassIfPropertyInError(x => x.TrainingCode, "error")">
+        <hr />
+        <label class="form-label-bold" for="TrainingCode">Apprenticeship training course</label>
         <span class="form-hint">Start typing in the name of the course or choose an option from the list</span>
-        @Html.ValidationMessageFor(m => m.TrainingCode, "Choose a training course for this apprentice", new {id = "error-message-" + Html.IdFor(m => m.TrainingCode), @class = "error-message"})
+        @Html.ValidationMessageFor(m => m.TrainingCode, "Choose a training course for this apprentice", new { id = "error-message-" + Html.IdFor(m => m.TrainingCode), @class = "error-message" })
         <select name="TrainingCode" id="TrainingCode" class="form-control form-control-3-4" aria-label="Apprenticeship training course">
             <option value="">Please select</option>
             @foreach (var programme in ViewBag.ApprenticeshipProgrammes)
             {
-                <option value="@programme.Id"
-                        @if (programme.Id.ToString() == Model.TrainingCode)
-                        {
-                            @Html.Raw("selected")
-                        }>
+                <option value="@programme.Id" @if (programme.Id.ToString() == Model.TrainingCode) { @Html.Raw("selected") }>
                     @programme.Title
                 </option>
             }
         </select>
-    }
-</div>
+    </div>
+}
 
 <div class="form-error-group form-group @Html.AddClassIfPropertyInError(x => x.StartDate, "error") @Html.AddClassIfPropertyInError(x => x.StartDate, "error") @Html.AddClassIfPropertyInError("StartDateOverlap", "error")">
     <hr />
@@ -92,8 +107,8 @@
 
             <span>@Model.StartDate.DateTime.Value.ToGdsFormatWithoutDay()</span>
 
-            @Html.Hidden("StartDate.Month", Model.StartDate.Month)
-            @Html.Hidden("StartDate.Year", Model.StartDate.Year)
+            @Html.HiddenFor(m => m.StartDate.Month)
+            @Html.HiddenFor(m => m.StartDate.Year)
         }
         else
         {

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/dist/javascripts/apprentice/dropdown.js
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/dist/javascripts/apprentice/dropdown.js
@@ -2,8 +2,8 @@
 
     // https://select2.github.io/examples.html
     var init = function () {
-        if ($("#TrainingCode")) {
-            $("#TrainingCode").select2();
+        if ($("select#TrainingCode")) {
+            $("select#TrainingCode").select2();
         }
     };
 
@@ -17,22 +17,22 @@
      });
 
     // retain tabbed order after selection
-    $('#TrainingCode').on('select2:select', function () {
+    $('select#TrainingCode').on('select2:select', function () {
         $("#StartMonth").focus();
     });
 
     // retain tabbed order on close without selection
-    $('#TrainingCode').on('select2:close', function () {
+    $('select#TrainingCode').on('select2:close', function () {
         $("#StartMonth").focus();
     });
 
     // retain tabbed order after selection
-    $('#TrainingCode').on('select2:select', function () {
+    $('select#TrainingCode').on('select2:select', function () {
         $("#StartDate_Month").focus();
     });
 
     // retain tabbed order on close without selection
-    $('#TrainingCode').on('select2:close', function () {
+    $('select#TrainingCode').on('select2:close', function () {
         $("#StartDate_Month").focus();
     });
 


### PR DESCRIPTION
Apply partial or full lockdown to edit apprenticeship page according to scenarios documented in story.
Also, brings the EditApprenticeship & EditStartedApprenticeship partials closer together, includes...
* show StartDateTransfersMinDateAltDetailMessage for apprenticeships yet to start
* add 'enter max of 20 chars' to reference field when apprenticeship started