### PR TITLE
Fixed failing test due to use of dynamic date

### DIFF
--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests/Validation/ApprenticeshipCreateOrEdit/WhenValidatingTrainingDates.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests/Validation/ApprenticeshipCreateOrEdit/WhenValidatingTrainingDates.cs
@@ -57,7 +57,7 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests.Validation.Appren
         [TestCase(0, 0, 0, "The end date is not valid")]
         [TestCase(1, 18, 2121, "The end date is not valid")]
         [TestCase(5, 9, 1998, "The end date must not be in the past")]
-        public void ShouldFailValidationForPlanedEndDate(int? day, int? month, int? year, string expected)
+        public void ShouldFailValidationForPlannedEndDate(int? day, int? month, int? year, string expected)
         {
 
             ValidModel.EndDate = new DateTimeViewModel(day, month, year);
@@ -84,7 +84,7 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests.Validation.Appren
         [Test]
         public void ShouldFailValidationForPlanedEndDate()
         {
-            var date = DateTime.Now;
+            var date = new DateTime(2018, 4, 1);
             ValidModel.EndDate = new DateTimeViewModel(date.Day, date.Month, date.Year);
 
             var result = Validator.Validate(ValidModel);


### PR DESCRIPTION
Renamed test due to confusion in test viewer (name conflict)