### PR TITLE
Removed ProviderPermission model and references to the ProviderRelati…

### DIFF
--- a/src/SFA.DAS.CloudService/Configuration/ServiceDefinition.Cloud.csdef
+++ b/src/SFA.DAS.CloudService/Configuration/ServiceDefinition.Cloud.csdef
@@ -20,7 +20,6 @@
       <Setting name="InstrumentationKey" />
       <Setting name="RedisSessionProviderConnectionString" />
       <Setting name="CurrentTime" />
-      <Setting name="FeatureToggle.ProviderRelationships" />
       <Setting name="UseStubProviderRelationships" />
     </ConfigurationSettings>
     <Endpoints>

--- a/src/SFA.DAS.CloudService/Configuration/ServiceDefinition.Release.csdef
+++ b/src/SFA.DAS.CloudService/Configuration/ServiceDefinition.Release.csdef
@@ -20,7 +20,6 @@
       <Setting name="InstrumentationKey" />
       <Setting name="RedisSessionProviderConnectionString" />
       <Setting name="CurrentTime" />
-      <Setting name="FeatureToggle.ProviderRelationships" />
       <Setting name="UseStubProviderRelationships" />
     </ConfigurationSettings>
     <Endpoints>

--- a/src/SFA.DAS.CloudService/ServiceConfiguration.Cloud.cscfg
+++ b/src/SFA.DAS.CloudService/ServiceConfiguration.Cloud.cscfg
@@ -14,7 +14,6 @@
       <Setting name="InstrumentationKey" value="__InstrumentationKey__" />
       <Setting name="RedisSessionProviderConnectionString" value="__RedisSessionProviderConnectionString__" />
       <Setting name="CurrentTime" value="" />
-      <Setting name="FeatureToggle.ProviderRelationships" value="__FeatureToggle.ProviderRelationships__" />
       <Setting name="UseStubProviderRelationships" value="__UseStubProviderRelationships__" />
     </ConfigurationSettings>
     <Certificates>

--- a/src/SFA.DAS.CloudService/ServiceConfiguration.Local.cscfg
+++ b/src/SFA.DAS.CloudService/ServiceConfiguration.Local.cscfg
@@ -14,7 +14,6 @@
       <Setting name="InstrumentationKey" value="" />
       <Setting name="RedisSessionProviderConnectionString" value="127.0.0.1" />
       <Setting name="CurrentTime" value="" />
-      <Setting name="FeatureToggle.ProviderRelationships" value="true" />
       <Setting name="UseStubProviderRelationships" value="true" />
     </ConfigurationSettings>
     <Certificates>

--- a/src/SFA.DAS.CloudService/ServiceConfiguration.MO.cscfg
+++ b/src/SFA.DAS.CloudService/ServiceConfiguration.MO.cscfg
@@ -14,7 +14,6 @@
       <Setting name="InstrumentationKey" value="__InstrumentationKey__" />
       <Setting name="RedisSessionProviderConnectionString" value="__RedisSessionProviderConnectionString__" />
       <Setting name="CurrentTime" value="" />
-      <Setting name="FeatureToggle.ProviderRelationships" value="__FeatureToggle.ProviderRelationships__" />
       <Setting name="UseStubProviderRelationships" value="__UseStubProviderRelationships__" />
     </ConfigurationSettings>
     <Certificates>

--- a/src/SFA.DAS.CloudService/ServiceConfiguration.PreProd.cscfg
+++ b/src/SFA.DAS.CloudService/ServiceConfiguration.PreProd.cscfg
@@ -14,7 +14,6 @@
       <Setting name="InstrumentationKey" value="__InstrumentationKey__" />
       <Setting name="RedisSessionProviderConnectionString" value="__RedisSessionProviderConnectionString__" />
       <Setting name="CurrentTime" value="" />
-      <Setting name="FeatureToggle.ProviderRelationships" value="__FeatureToggle.ProviderRelationships__" />
       <Setting name="UseStubProviderRelationships" value="__UseStubProviderRelationships__" />
     </ConfigurationSettings>
     <Certificates>

--- a/src/SFA.DAS.CloudService/ServiceConfiguration.Release.cscfg
+++ b/src/SFA.DAS.CloudService/ServiceConfiguration.Release.cscfg
@@ -14,7 +14,6 @@
       <Setting name="InstrumentationKey" value="__InstrumentationKey__" />
       <Setting name="RedisSessionProviderConnectionString" value="__RedisSessionProviderConnectionString__" />
       <Setting name="CurrentTime" value="" />
-      <Setting name="FeatureToggle.ProviderRelationships" value="__FeatureToggle.ProviderRelationships__" />
       <Setting name="UseStubProviderRelationships" value="__UseStubProviderRelationships__" />
     </ConfigurationSettings>
     <Certificates>

--- a/src/SFA.DAS.CloudService/ServiceDefinition.csdef
+++ b/src/SFA.DAS.CloudService/ServiceDefinition.csdef
@@ -20,7 +20,6 @@
       <Setting name="InstrumentationKey" />
       <Setting name="RedisSessionProviderConnectionString" />
       <Setting name="CurrentTime" />
-      <Setting name="FeatureToggle.ProviderRelationships" />
       <Setting name="UseStubProviderRelationships" />
     </ConfigurationSettings>
     <Endpoints>

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Domain/Models/FeatureToggles/ProviderRelationships.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Domain/Models/FeatureToggles/ProviderRelationships.cs
@@ -1,8 +1,0 @@
-﻿using FeatureToggle;
-
-namespace SFA.DAS.ProviderApprenticeshipsService.Domain.Models.FeatureToggles
-{
-    public class ProviderRelationships : SimpleFeatureToggle
-    {
-    }
-}

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Domain/SFA.DAS.ProviderApprenticeshipsService.Domain.csproj
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Domain/SFA.DAS.ProviderApprenticeshipsService.Domain.csproj
@@ -172,7 +172,6 @@
     <Compile Include="Interfaces\IUserSettingsRepository.cs" />
     <Compile Include="Models\ApprenticeshipCourse\ITrainingProgramme.cs" />
     <Compile Include="Models\Apprenticeship\FundingStatus.cs" />
-    <Compile Include="Models\FeatureToggles\ProviderRelationships.cs" />
     <Compile Include="Models\Organisation\LegalEntity.cs" />
     <Compile Include="Models\Settings\UserNotificationSetting.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -193,7 +192,9 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Folder Include="Models\FeatureToggles\" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests/Orchestrators/Account/WhenGettingAccountHomeViewModel.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests/Orchestrators/Account/WhenGettingAccountHomeViewModel.cs
@@ -22,9 +22,7 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests.Orchestrators.Acc
         private AccountOrchestrator _orchestrator;
         private Mock<IMediator> _mediator;
         private Mock<ICurrentDateTime> _currentDateTime;
-        private Mock<IFeatureToggleService> _featureToggleService;
-        private Mock<IFeatureToggle> _featureToggle;
-
+        
         [SetUp]
         public void Arrange()
         {
@@ -46,17 +44,12 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests.Orchestrators.Acc
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(() => new GetProviderHasRelationshipWithPermissionQueryResponse());
 
-            _featureToggle = new Mock<IFeatureToggle>();
-            _featureToggleService = new Mock<IFeatureToggleService>();
-            _featureToggleService.Setup(x => x.Get<Domain.Models.FeatureToggles.ProviderRelationships>()).Returns(_featureToggle.Object);
-            
-            _currentDateTime = new Mock<ICurrentDateTime>();
+           _currentDateTime = new Mock<ICurrentDateTime>();
 
             _orchestrator = new AccountOrchestrator(
                 _mediator.Object,
                 Mock.Of<ILog>(),
-                _currentDateTime.Object,
-                _featureToggleService.Object
+                _currentDateTime.Object
             );
         }
 
@@ -68,28 +61,6 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests.Orchestrators.Acc
             var model = await _orchestrator.GetAccountHomeViewModel(1);
 
             model.ShowAcademicYearBanner.Should().Be(expectShowBanner);
-        }
-
-        [TestCase(true, true, true, Description = "Show link if feature is enabled and provider has relevant permission" )]
-        [TestCase(true, false, false, Description = "Hide link if feature is enabled but provider does not have relevant permission")]
-        [TestCase(false, true, false, Description = "Hide link if feature is disabled but provider has relevant permission")]
-        [TestCase(false, false, false, Description = "Hide link if feature is disabled and provider does not has relevant permission")]
-        public async Task ThenDisplayOfCreateCohortLinkIsDetermined(bool featureEnabled, bool hasPermission, bool expectShowLink)
-        {
-            //Arrange
-            _featureToggle.Setup(x => x.FeatureEnabled).Returns(featureEnabled);
-
-            _mediator.Setup(x =>
-                    x.Send(It.Is<GetProviderHasRelationshipWithPermissionQueryRequest>(r =>
-                            r.Permission == Operation.CreateCohort),
-                        It.IsAny<CancellationToken>()))
-                .ReturnsAsync(() => new GetProviderHasRelationshipWithPermissionQueryResponse{ HasPermission = hasPermission});
-
-            //Act
-            var model = await _orchestrator.GetAccountHomeViewModel(1);
-
-            //Assert
-            model.ShowCreateCohortLink.Should().Be(expectShowLink);
         }
     }
 }

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests/Orchestrators/Commitments/ApprenticeshipValidationTestBase.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests/Orchestrators/Commitments/ApprenticeshipValidationTestBase.cs
@@ -32,9 +32,7 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests.Orchestrators.Com
         protected Mock<IHashingService> _mockHashingService = new Mock<IHashingService>();
         protected Mock<IApprenticeshipCoreValidator> _mockApprenticeshipCoreValidator = new Mock<IApprenticeshipCoreValidator>();
         protected Mock<IApprenticeshipMapper> _mockMapper = new Mock<IApprenticeshipMapper>();
-        protected Mock<IFeatureToggleService> MockFeatureToggleService;
-        protected Mock<IFeatureToggle> MockFeatureToggleOn;
-
+        
         private Mock<ApprenticeshipViewModelUniqueUlnValidator> _ulnValidator;
 
         [SetUp]
@@ -48,12 +46,6 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests.Orchestrators.Com
                 .Setup(m => m.ValidateAsyncOverride(It.IsAny<ApprenticeshipViewModel>()))
                 .ReturnsAsync(new ValidationResult());
 
-            MockFeatureToggleOn = new Mock<IFeatureToggle>();
-            MockFeatureToggleOn.Setup(x => x.FeatureEnabled).Returns(true);
-            MockFeatureToggleService = new Mock<IFeatureToggleService>();
-            MockFeatureToggleService.Setup(x => x.Get<Domain.Models.FeatureToggles.ProviderRelationships>())
-                .Returns(MockFeatureToggleOn.Object);           
-
             SetUpOrchestrator();
         }
 
@@ -66,8 +58,7 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests.Orchestrators.Com
                        _ulnValidator.Object,
                        Mock.Of<ProviderApprenticeshipsServiceConfiguration>(),
                        _mockApprenticeshipCoreValidator.Object,
-                       _mockMapper.Object,
-                       MockFeatureToggleService.Object);
+                       _mockMapper.Object);
         }
 
         protected CommitmentListItem GetTestCommitmentOfStatus(long id, RequestStatus requestStatus)

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests/Orchestrators/Commitments/WhenGetCohorts.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests/Orchestrators/Commitments/WhenGetCohorts.cs
@@ -66,25 +66,6 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests.Orchestrators.Com
         }
 
         [Test]
-        public async Task ThenDraftsAreNotShownIfProviderRelationshipsFeatureNotToggledOn()
-        {
-            //Arrange
-            MockFeatureToggleOn.Setup(x => x.FeatureEnabled).Returns(false);
-
-            _mockMediator.Setup(x => x.Send(It.IsAny<GetCommitmentsQueryRequest>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new GetCommitmentsQueryResponse
-                {
-                    Commitments = new List<CommitmentListItem>()
-                });
-
-            //Act
-            var result = await _orchestrator.GetCohorts(1234567);
-
-            //Assert
-            Assert.IsFalse(result.ShowDrafts);
-        }
-
-        [Test]
         public async Task ThenDraftsAreNotShownIfProviderHasNoPermissions()
         {
             //Arrange

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests/Orchestrators/Commitments/WhenGettingDraftCohorts.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests/Orchestrators/Commitments/WhenGettingDraftCohorts.cs
@@ -69,8 +69,7 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests.Orchestrators.Com
                 Mock.Of<ApprenticeshipViewModelUniqueUlnValidator>(),
                 Mock.Of<ProviderApprenticeshipsServiceConfiguration>(),
                 Mock.Of<IApprenticeshipCoreValidator>(),
-                Mock.Of<IApprenticeshipMapper>(),
-                Mock.Of<IFeatureToggleService>()
+                Mock.Of<IApprenticeshipMapper>()
             );
         }
 

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Orchestrators/AccountOrchestrator.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Orchestrators/AccountOrchestrator.cs
@@ -25,17 +25,14 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.Orchestrators
         private readonly IMediator _mediator;
         private readonly ILog _logger;
         private readonly ICurrentDateTime _currentDateTime;
-        private readonly IFeatureToggleService _featureToggleService;
 
         public AccountOrchestrator(IMediator mediator,
             ILog logger,
-            ICurrentDateTime currentDateTime,
-            IFeatureToggleService featureToggleService)
+            ICurrentDateTime currentDateTime)
         {
             _mediator = mediator;
             _logger = logger;
             _currentDateTime = currentDateTime;
-            _featureToggleService = featureToggleService;
         }
 
         public async Task<AccountHomeViewModel> GetAccountHomeViewModel(int providerId)
@@ -45,12 +42,7 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.Orchestrators
                 _logger.Info($"Getting provider {providerId}");
 
                 var providerResponse = await _mediator.Send(new GetProviderQueryRequest { UKPRN = providerId });
-
-                var showCreateCohortLink = false;
-                if (_featureToggleService.Get<Domain.Models.FeatureToggles.ProviderRelationships>().FeatureEnabled)
-                {
-                    showCreateCohortLink = await ProviderHasPermission(providerId, Operation.CreateCohort);
-                }                  
+                var showCreateCohortLink = await ProviderHasPermission(providerId, Operation.CreateCohort);
 
                 return new AccountHomeViewModel
                 {

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Orchestrators/CommitmentOrchestrator.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Orchestrators/CommitmentOrchestrator.cs
@@ -42,7 +42,6 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.Orchestrators
         private readonly IApprenticeshipMapper _apprenticeshipMapper;
         private readonly ApprenticeshipViewModelUniqueUlnValidator _uniqueUlnValidator;
         private readonly ProviderApprenticeshipsServiceConfiguration _configuration;
-        private readonly IFeatureToggleService _featureToggleService;
         private readonly Func<int, string> _addSSuffix = i => i > 1 ? "s" : "";
 
         public CommitmentOrchestrator(IMediator mediator,
@@ -50,31 +49,25 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.Orchestrators
             ApprenticeshipViewModelUniqueUlnValidator uniqueUlnValidator,
             ProviderApprenticeshipsServiceConfiguration configuration,
             IApprenticeshipCoreValidator apprenticeshipCoreValidator,
-            IApprenticeshipMapper apprenticeshipMapper,
-            IFeatureToggleService featureToggleService)
+            IApprenticeshipMapper apprenticeshipMapper)
             : base(mediator, hashingService, logger)
         {
             _uniqueUlnValidator = uniqueUlnValidator;
             _configuration = configuration;
             _apprenticeshipCoreValidator = apprenticeshipCoreValidator;
             _apprenticeshipMapper = apprenticeshipMapper;
-            _featureToggleService = featureToggleService;
         }
 
         public async Task<CohortsViewModel> GetCohorts(long providerId)
         {
             Logger.Info($"Getting cohorts :{providerId}", providerId);
-
-            var showDrafts = _featureToggleService.Get<Domain.Models.FeatureToggles.ProviderRelationships>().FeatureEnabled;
-            if (showDrafts)
-            {
+            
                 var relationshipResponse = await Mediator.Send(new GetProviderHasRelationshipWithPermissionQueryRequest
                 {
                     ProviderId = providerId,
                     Permission = Operation.CreateCohort
                 });
-                showDrafts = relationshipResponse.HasPermission;
-            }
+                var showDrafts = relationshipResponse.HasPermission;
 
             var data = await Mediator.Send(new GetCommitmentsQueryRequest
             {


### PR DESCRIPTION
…onships feature toggle.


There are a couple of references to IFeatureToggleService remaining for 2 reasons:
CV-35 will require it, so it remains in the dependency resolution.
There are a couple of unit tests that don't care about what toggle it is, so I've left it in to cover CV-35 when they get merged.