### PR TITLE
ER-889 - Added provider agreement endpoint to Pas.Account.Api

### DIFF
--- a/src/SFA.DAS.PAS.Account.Api.Types/ProviderAgreement.cs
+++ b/src/SFA.DAS.PAS.Account.Api.Types/ProviderAgreement.cs
@@ -2,6 +2,6 @@
 {
     public class ProviderAgreement
     {
-        public string Status { get; set; }
+        public ProviderAgreementStatus Status { get; set; }
     }
 }

--- a/src/SFA.DAS.PAS.Account.Api.Types/ProviderAgreement.cs
+++ b/src/SFA.DAS.PAS.Account.Api.Types/ProviderAgreement.cs
@@ -1,0 +1,7 @@
+﻿namespace SFA.DAS.PAS.Account.Api.Types
+{
+    public class ProviderAgreement
+    {
+        public string Status { get; set; }
+    }
+}

--- a/src/SFA.DAS.PAS.Account.Api.Types/ProviderAgreementStatus.cs
+++ b/src/SFA.DAS.PAS.Account.Api.Types/ProviderAgreementStatus.cs
@@ -1,0 +1,8 @@
+﻿namespace SFA.DAS.PAS.Account.Api.Types
+{
+    public enum ProviderAgreementStatus
+    {
+        NotAgreed,
+        Agreed
+    }
+}

--- a/src/SFA.DAS.PAS.Account.Api.Types/SFA.DAS.PAS.Account.Api.Types.csproj
+++ b/src/SFA.DAS.PAS.Account.Api.Types/SFA.DAS.PAS.Account.Api.Types.csproj
@@ -44,6 +44,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EmailMessage.cs" />
+    <Compile Include="ProviderAgreement.cs" />
     <Compile Include="User.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/SFA.DAS.PAS.Account.Api.Types/SFA.DAS.PAS.Account.Api.Types.csproj
+++ b/src/SFA.DAS.PAS.Account.Api.Types/SFA.DAS.PAS.Account.Api.Types.csproj
@@ -45,6 +45,7 @@
   <ItemGroup>
     <Compile Include="EmailMessage.cs" />
     <Compile Include="ProviderAgreement.cs" />
+    <Compile Include="ProviderAgreementStatus.cs" />
     <Compile Include="User.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/SFA.DAS.PAS.Account.Api.UnitTests/Orchestrator/WhenGettingAgreement.cs
+++ b/src/SFA.DAS.PAS.Account.Api.UnitTests/Orchestrator/WhenGettingAgreement.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoFixture;
+using FluentAssertions;
+using MediatR;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.PAS.Account.Api.Orchestrator;
+using SFA.DAS.ProviderApprenticeshipsService.Application.Queries.GetProviderAgreement;
+using SFA.DAS.ProviderApprenticeshipsService.Domain;
+using SFA.DAS.ProviderApprenticeshipsService.Domain.Interfaces;
+
+namespace SFA.DAS.PAS.Account.Api.UnitTests.Orchestrator
+{
+    [TestFixture]
+    public class WhenGettingAgreement
+    {
+        private const long Ukprn = 12345678;
+
+        private AccountOrchestrator _sut;
+        private Mock<IMediator> _mediator;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mediator = new Mock<IMediator>();
+            _sut = new AccountOrchestrator(_mediator.Object, Mock.Of<IProviderCommitmentsLogger>());
+        }
+
+        [TestCase(ProviderAgreementStatus.Agreed)]
+        [TestCase(ProviderAgreementStatus.NotAgreed)]
+        public async Task ShouldReturnAgreement(ProviderAgreementStatus expectedStatus)
+        {
+            var response = new GetProviderAgreementQueryResponse
+            {
+                HasAgreement = expectedStatus
+            };
+
+            _mediator.Setup(m => m.Send(
+                It.Is<GetProviderAgreementQueryRequest>(r => r.ProviderId == Ukprn),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(response);
+
+            var result = await _sut.GetAgreement(Ukprn);
+
+            result.Status.Should().Be(expectedStatus.ToString());
+        }
+    }
+}

--- a/src/SFA.DAS.PAS.Account.Api.UnitTests/Orchestrator/WhenGettingAgreement.cs
+++ b/src/SFA.DAS.PAS.Account.Api.UnitTests/Orchestrator/WhenGettingAgreement.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using AutoFixture;
 using FluentAssertions;
 using MediatR;
 using Moq;
@@ -47,7 +43,9 @@ namespace SFA.DAS.PAS.Account.Api.UnitTests.Orchestrator
 
             var result = await _sut.GetAgreement(Ukprn);
 
-            result.Status.Should().Be(expectedStatus.ToString());
+            var apiAgreementStatus = (Types.ProviderAgreementStatus) Enum.Parse(typeof(Types.ProviderAgreementStatus), expectedStatus.ToString());
+
+            result.Status.Should().Be(apiAgreementStatus);
         }
     }
 }

--- a/src/SFA.DAS.PAS.Account.Api.UnitTests/SFA.DAS.PAS.Account.Api.UnitTests.csproj
+++ b/src/SFA.DAS.PAS.Account.Api.UnitTests/SFA.DAS.PAS.Account.Api.UnitTests.csproj
@@ -77,6 +77,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Orchestrator\WhenGettingAccountUsers.cs" />
+    <Compile Include="Orchestrator\WhenGettingAgreement.cs" />
     <Compile Include="Orchestrator\WhenSendingEmailToAllProviderRecipients.cs" />
     <Compile Include="Orchestrator\WhenSendingEmailToAllProviderRecipients_ExplicitEmailAddresses.cs" />
     <Compile Include="Orchestrator\WhenSendingEmailToAllProviderRecipients_IdamsEmails.cs" />

--- a/src/SFA.DAS.PAS.Account.Api/App_Start/WebApiConfig.cs
+++ b/src/SFA.DAS.PAS.Account.Api/App_Start/WebApiConfig.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net.Http.Headers;
 using System.Web.Http;
 using System.Web.Http.ExceptionHandling;
+using Newtonsoft.Json.Converters;
 
 namespace SFA.DAS.PAS.Account.Api
 {
@@ -11,6 +12,7 @@ namespace SFA.DAS.PAS.Account.Api
             // Web API configuration and services
             // Configure Web API to use only bearer token authentication.
             config.Formatters.JsonFormatter.SupportedMediaTypes.Add(new MediaTypeHeaderValue("text/html"));
+            config.Formatters.JsonFormatter.SerializerSettings.Converters.Add(new StringEnumConverter());
 
             config.MapHttpAttributeRoutes();
 

--- a/src/SFA.DAS.PAS.Account.Api/Controllers/AccountController.cs
+++ b/src/SFA.DAS.PAS.Account.Api/Controllers/AccountController.cs
@@ -1,7 +1,6 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
 using System.Web.Http;
-
 using SFA.DAS.PAS.Account.Api.Attributes;
 using SFA.DAS.PAS.Account.Api.Orchestrator;
 using SFA.DAS.ProviderApprenticeshipsService.Domain.Interfaces;
@@ -32,6 +31,19 @@ namespace SFA.DAS.PAS.Account.Api.Controllers
             var result = await _orchestrator.GetAccountUsers(ukprn);
 
             _logger.Info($"Found {result.Count()} user accounts for ukprn: {ukprn}", providerId: ukprn);
+
+            return Ok(result);
+        }
+
+        [Route("{ukprn}/agreement")]
+        [HttpGet]
+        [ApiAuthorize(Roles = "ReadAccountUsers")]
+        public async Task<IHttpActionResult> GetAgreement(long ukprn)
+        {
+            _logger.Info($"Getting agreement for ukprn: {ukprn}", providerId: ukprn);
+            var result = await _orchestrator.GetAgreement(ukprn);
+
+            _logger.Info($"Ukprn: {ukprn} has agreement status: {result.Status}", providerId: ukprn);
 
             return Ok(result);
         }

--- a/src/SFA.DAS.PAS.Account.Api/DependencyResolution/DefaultRegistry.cs
+++ b/src/SFA.DAS.PAS.Account.Api/DependencyResolution/DefaultRegistry.cs
@@ -37,10 +37,13 @@ using System.Net.Http;
 using SFA.DAS.Notifications.Api.Client;
 using SFA.DAS.Http.TokenGenerators;
 using SFA.DAS.Notifications.Api.Client.Configuration;
+using SFA.DAS.ProviderApprenticeshipsService.Domain.Data;
 using SFA.DAS.ProviderApprenticeshipsService.Infrastructure.Data;
+using SFA.DAS.ProviderApprenticeshipsService.Infrastructure.Services;
 using SFA.DAS.Http;
 
 namespace SFA.DAS.PAS.Account.Api.DependencyResolution {
+    
     using StructureMap.Graph;
 
 
@@ -57,13 +60,17 @@ namespace SFA.DAS.PAS.Account.Api.DependencyResolution {
                     //scan.ConnectImplementationsToTypesClosing(typeof(IAsyncRequestHandler<,>));
                     scan.ConnectImplementationsToTypesClosing(typeof(INotificationHandler<>));
                     //scan.ConnectImplementationsToTypesClosing(typeof(IAsyncNotificationHandler<>));
+                    scan.AddAllTypesOf<IAgreementStatusQueryRepository>();
                 });
 
             var config = GetConfiguration();
 
             For<IConfiguration>().Use(config);
+            For<IProviderAgreementStatusConfiguration>().Use(config);
             For<ProviderApprenticeshipsServiceConfiguration>().Use(config);
 
+            For<ICurrentDateTime>().Use(x => new CurrentDateTime());
+            
             ConfigureNotificationsApi(config);
             ConfigureHttpClient(config);
 

--- a/src/SFA.DAS.PAS.Account.Api/Orchestrator/AccountOrchestrator.cs
+++ b/src/SFA.DAS.PAS.Account.Api/Orchestrator/AccountOrchestrator.cs
@@ -1,11 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-
 using MediatR;
-
 using SFA.DAS.PAS.Account.Api.Types;
 using SFA.DAS.ProviderApprenticeshipsService.Application.Queries.GetAccountUsers;
+using SFA.DAS.ProviderApprenticeshipsService.Application.Queries.GetProviderAgreement;
 using SFA.DAS.ProviderApprenticeshipsService.Domain.Interfaces;
 
 namespace SFA.DAS.PAS.Account.Api.Orchestrator
@@ -29,6 +28,20 @@ namespace SFA.DAS.PAS.Account.Api.Orchestrator
             return result.UserSettings.Select(
                 m =>
                 new User { EmailAddress = m.User.Email, ReceiveNotifications = m.Setting?.ReceiveNotifications ?? true, UserRef = m.User.UserRef });
+        }
+
+        public async Task<ProviderAgreement> GetAgreement(long providerId)
+        {
+            var data = await _mediator.Send(
+                new GetProviderAgreementQueryRequest
+                {
+                    ProviderId = providerId
+                });
+
+            return new ProviderAgreement
+            {
+                Status = data.HasAgreement.ToString()
+            };
         }
     }
 }

--- a/src/SFA.DAS.PAS.Account.Api/Orchestrator/AccountOrchestrator.cs
+++ b/src/SFA.DAS.PAS.Account.Api/Orchestrator/AccountOrchestrator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using MediatR;
@@ -40,7 +41,7 @@ namespace SFA.DAS.PAS.Account.Api.Orchestrator
 
             return new ProviderAgreement
             {
-                Status = data.HasAgreement.ToString()
+                Status = (ProviderAgreementStatus)Enum.Parse(typeof(ProviderAgreementStatus), data.HasAgreement.ToString())
             };
         }
     }


### PR DESCRIPTION
For `das-recruit` we need to ensure the provider has a signed agreement before they are allowed to submit a vacancy.

I've extended the `AccountController` to add a new endpoint `/api/account/{ukprn}/agreement`. This will  return whether the provider has an agreement or not.
