### PR TITLE
Map 96 add manifest file

### DIFF
--- a/as-manifest.yml
+++ b/as-manifest.yml
@@ -1,0 +1,18 @@
+team: MAP
+
+businessApplication: Provider Portal
+
+features:
+-Provider Portal
+-Provider Agreements
+-Provider Login (client)
+-Provider API
+
+aka:
+PAS
+
+kind:
+- frontend 
+- api
+- worker
+- database

--- a/as-manifest.yml
+++ b/as-manifest.yml
@@ -1,3 +1,5 @@
+schema: https://github.com/SkillsFundingAgency/das-technical-guidance/blob/collections/_development_standards/as-manifest.schema.yaml
+
 team: MAP
 
 businessApplication: Provider Portal

--- a/as-manifest.yml
+++ b/as-manifest.yml
@@ -3,13 +3,11 @@ team: MAP
 businessApplication: Provider Portal
 
 features:
--Provider Portal
--Provider Agreements
--Provider Login (client)
--Provider API
+- Provider Portal
+- Provider Agreements
+- Provider Login (client)
+- Provider API
 
-aka:
-PAS
 
 kind:
 - frontend 
@@ -18,4 +16,4 @@ kind:
 - database
 
 links:
-https://providers.apprenticeships.education.gov.uk/
+- https://providers.apprenticeships.education.gov.uk/

--- a/as-manifest.yml
+++ b/as-manifest.yml
@@ -16,3 +16,6 @@ kind:
 - api
 - worker
 - database
+
+links:
+https://providers.apprenticeships.education.gov.uk/


### PR DESCRIPTION
This is to add a manifest file to allow the service as a whole to understand the content of the repository. This is the first attempt at this and so may need changing as we roll this out wider. 

However its the content we currently think is suitable.