### PR TITLE
Integrating DfESignIn with ProviderApprenticeshipsService

### DIFF
--- a/src/SFA.DAS.PAS.ContractAgreements.WebJob/App.config
+++ b/src/SFA.DAS.PAS.ContractAgreements.WebJob/App.config
@@ -260,6 +260,22 @@
         <assemblyIdentity name="System.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.8.1.0" newVersion="5.8.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.0.0" newVersion="5.6.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.0.0" newVersion="5.6.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <system.web>

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Domain/Interfaces/IDfESignInService.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Domain/Interfaces/IDfESignInService.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+
+namespace SFA.DAS.ProviderApprenticeshipsService.Domain.Interfaces
+{
+    public interface IDfESignInService
+    {
+        /// <summary>
+        /// method to get the response from remote source.
+        /// </summary>
+        /// <typeparam name="T">Response model.</typeparam>
+        /// <param name="userOrgId">User Org Id.</param>
+        /// <param name="userId">User Id.</param>
+        /// <returns>Response model.</returns>
+        Task<T> Get<T>(string userOrgId, string userId);
+    }
+}

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Domain/Interfaces/IDfESignInServiceConfiguration.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Domain/Interfaces/IDfESignInServiceConfiguration.cs
@@ -1,0 +1,9 @@
+﻿using SFA.DAS.ProviderApprenticeshipsService.Domain.Models;
+
+namespace SFA.DAS.ProviderApprenticeshipsService.Domain.Interfaces
+{
+    public interface IDfESignInServiceConfiguration : IConfiguration
+    {
+        DfESignInConfig DfEOidcConfiguration { get; set; }
+    }
+}

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Domain/Models/DfESignInConfig.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Domain/Models/DfESignInConfig.cs
@@ -1,0 +1,38 @@
+﻿namespace SFA.DAS.ProviderApprenticeshipsService.Domain.Models
+{
+    /// <summary>
+    /// model to hold configurations of DfESignIn
+    /// </summary>
+    public class DfESignInConfig
+    {
+        /// <summary>
+        /// Gets or Sets BaseUrl
+        /// </summary>
+        public string BaseUrl { get; set; }
+
+        /// <summary>
+        /// Gets or Sets Client Identifier.
+        /// </summary>
+        public string ClientId { get; set; }
+
+        /// <summary>
+        /// Gets or Sets Secret.
+        /// </summary>
+        public string Secret { get; set; }
+
+        /// <summary>
+        /// Gets or Sets Api Service Url.
+        /// </summary>
+        public string ApiServiceUrl { get; set; }
+
+        /// <summary>
+        /// Gets or Sets Api Service Id.
+        /// </summary>
+        public string ApiServiceId { get; set; }
+
+        /// <summary>
+        /// Gets or Sets Api Service Secret.
+        /// </summary>
+        public string ApiServiceSecret { get; set; }
+    }
+}

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Domain/SFA.DAS.ProviderApprenticeshipsService.Domain.csproj
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Domain/SFA.DAS.ProviderApprenticeshipsService.Domain.csproj
@@ -243,6 +243,8 @@
     <Compile Include="Interfaces\ICacheStorageService.cs" />
     <Compile Include="Interfaces\IContentApiClient.cs" />
     <Compile Include="Interfaces\IContentClientApiConfiguration.cs" />
+    <Compile Include="Interfaces\IDfESignInService.cs" />
+    <Compile Include="Interfaces\IDfESignInServiceConfiguration.cs" />
     <Compile Include="Interfaces\IEmployerAccountService.cs" />
     <Compile Include="Interfaces\ICommitmentsV2ApiClient.cs" />
     <Compile Include="Interfaces\IRoatpCourseManagementWebConfiguration.cs" />
@@ -268,6 +270,7 @@
     <Compile Include="Interfaces\IUserRepository.cs" />
     <Compile Include="Interfaces\IUserSettingsRepository.cs" />
     <Compile Include="Models\Apprenticeship\FundingStatus.cs" />
+    <Compile Include="Models\DfESignInConfig.cs" />
     <Compile Include="Models\FeatureToggles\ProviderCreateCohortV2.cs" />
     <Compile Include="Models\FeatureToggles\ApprenticeDetailsV2.cs" />
     <Compile Include="Models\FeatureToggles\ProviderManageApprenticesV2.cs" />

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Infrastructure/Configuration/DfESignInServiceConfiguration.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Infrastructure/Configuration/DfESignInServiceConfiguration.cs
@@ -1,0 +1,15 @@
+﻿using SFA.DAS.ProviderApprenticeshipsService.Domain.Interfaces;
+using SFA.DAS.ProviderApprenticeshipsService.Domain.Models;
+
+namespace SFA.DAS.ProviderApprenticeshipsService.Infrastructure.Configuration
+{
+    /// <summary>
+    /// Model to read the DfESignIn configuration from Azure Table Storage.
+    /// </summary>
+    public class DfESignInServiceConfiguration : IDfESignInServiceConfiguration
+    {
+        public string DatabaseConnectionString { get; set; }
+        public string ServiceBusConnectionString { get; set; }
+        public DfESignInConfig DfEOidcConfiguration { get; set; }
+    }
+}

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Infrastructure/Configuration/ProviderApprenticeshipsServiceConfiguration.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Infrastructure/Configuration/ProviderApprenticeshipsServiceConfiguration.cs
@@ -30,6 +30,12 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Infrastructure.Configuration
         public string ContentApplicationId { get; set; }
         public int DefaultCacheExpirationInMinutes { get; set; }
         public ZenDeskConfiguration ZenDeskSettings { get; set; }
+        
+        /// <summary>
+        /// Gets or Sets property UseDfESignIn.
+        /// Property responsible for holding the DfESignIn toggle switch value.
+        /// </summary>
+        public bool UseDfESignIn { get; set; } = false; 
     }
 
     public class CommitmentsApiClientConfiguration : ICommitmentsApiClientConfiguration

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Infrastructure/SFA.DAS.ProviderApprenticeshipsService.Infrastructure.csproj
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Infrastructure/SFA.DAS.ProviderApprenticeshipsService.Infrastructure.csproj
@@ -416,6 +416,7 @@
     <Compile Include="Caching\TaskSynchronizationScope.cs" />
     <Compile Include="Configuration\ConfigurationPolicy.cs" />
     <Compile Include="Configuration\CurrentDatePolicy.cs" />
+    <Compile Include="Configuration\DfESignInServiceConfiguration.cs" />
     <Compile Include="Configuration\ProviderApprenticeshipsServiceConfiguration.cs" />
     <Compile Include="Data\BaseRepository.cs" />
     <Compile Include="Data\HttpClientWrapper.cs" />
@@ -439,6 +440,7 @@
     <Compile Include="Services\CloudConfigurationBooleanValueProvider.cs" />
     <Compile Include="Services\CookieStorageService.cs" />
     <Compile Include="Services\CurrentDateTime.cs" />
+    <Compile Include="Services\DfESignInService.cs" />
     <Compile Include="Services\EmployerAccountService.cs" />
     <Compile Include="Services\FeatureToggleService.cs" />
     <Compile Include="Services\IAccountLegalEntityPublicHashingService.cs" />

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Infrastructure/Services/DfESignInService.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Infrastructure/Services/DfESignInService.cs
@@ -1,0 +1,43 @@
+﻿using Newtonsoft.Json;
+using SFA.DAS.Authentication.Extensions.Legacy;
+using SFA.DAS.ProviderApprenticeshipsService.Domain.Interfaces;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.ProviderApprenticeshipsService.Infrastructure.Services
+{
+    /// <summary>
+    /// Class responsible for DfESignIn Service.
+    /// </summary>
+    public class DfESignInService : ApiClientBase, IDfESignInService
+    {
+        private readonly HttpClient _httpClient;
+        private readonly IDfESignInServiceConfiguration _config;
+
+        public DfESignInService(HttpClient client, IDfESignInServiceConfiguration config) : base(client)
+        {
+            _httpClient = client;
+            _config = config;
+        }
+
+        /// <inheritdoc  />
+        public async Task<T> Get<T>(string userId, string userOrgId)
+        {
+            var endpoint = GetEndPoint(userId, userOrgId);
+            var request = new HttpRequestMessage(HttpMethod.Get, endpoint);
+            var getResponse = await _httpClient.SendAsync(request);
+            return getResponse.IsSuccessStatusCode ? JsonConvert.DeserializeObject<T>(await getResponse.Content.ReadAsStringAsync()) : default;
+        }
+
+        /// <summary>
+        /// Method to generate the endpoint from configuration.
+        /// </summary>
+        /// <param name="userOrgId">User Org Id.</param>
+        /// <param name="userId">User Id.</param>
+        /// <returns>string.</returns>
+        private string GetEndPoint(string userId, string userOrgId)
+        {
+            return $"{_config.DfEOidcConfiguration.ApiServiceUrl}/services/{_config.DfEOidcConfiguration.ApiServiceId}/organisations/{userOrgId}/users/{userId}";
+        }
+    }
+}

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests/Extensions/ClaimsIdentityExtensionsTests.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests/Extensions/ClaimsIdentityExtensionsTests.cs
@@ -1,7 +1,10 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Security.Claims;
 using NUnit.Framework;
 using SFA.DAS.ProviderApprenticeshipsService.Web.Authentication;
+using SFA.DAS.ProviderApprenticeshipsService.Web.Constants;
 using SFA.DAS.ProviderApprenticeshipsService.Web.Extensions;
 
 namespace SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests.Extensions
@@ -23,6 +26,34 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.UnitTests.Extensions
 
             var roles = identity.Claims.Where(c => c.Type == ClaimTypes.Role).Select(c => c.Value).ToArray();
             CollectionAssert.AreEquivalent(expectedRoles, roles);
+        }
+
+        [TestCase(ClaimName.Email, "someEmail@test.com")]
+        [TestCase(ClaimName.GivenName, "some name")]
+        [TestCase(ClaimName.Organisation, "DOE")]
+        [TestCase(ClaimName.NameIdentifier, "Full Name")]
+        [TestCase(ClaimName.RoleCode, "")]
+        public void GetClaimValue_When_GivenClaimName_Return_Expected(string claimName, string expectedValue)
+        {
+            // arrange
+            var identity = GetMockClaimsIdentity();
+
+            // sut
+            var actualValue = identity.GetClaimValue(claimName);
+
+            // assert
+            Assert.AreEqual(expectedValue, actualValue);
+        }
+
+        private static ClaimsIdentity GetMockClaimsIdentity()
+        {
+            return new ClaimsIdentity(new List<Claim>
+            {
+                new Claim(ClaimName.Email, "someEmail@test.com"),
+                new Claim(ClaimName.GivenName, "some name"),
+                new Claim(ClaimName.Organisation, "DOE"),
+                new Claim(ClaimName.NameIdentifier, "Full Name"),
+            }, "TestAuthType");
         }
     }
 }

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Api/Helpers/JsonWebAlgorithm.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Api/Helpers/JsonWebAlgorithm.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+
+namespace SFA.DAS.ProviderApprenticeshipsService.Web.Api.Helpers
+{
+    /// <summary>
+    /// Currently supports variants of HMAC Algorithm 
+    /// </summary>
+    public static class JsonWebAlgorithm
+    {
+        private static readonly Dictionary<string, string> Algorithm = new Dictionary<string, string>
+        {
+            { "HMACSHA1", "HS1" },
+            { "HMACSHA256", "HS256" },
+            { "HMACSHA384", "HS384" },
+            { "HMACSHA512", "HS512" }
+        };
+
+        public static string GetAlgorithm(string algorithm)
+        {
+            if (!Algorithm.ContainsKey(algorithm)) throw new KeyNotFoundException("Cannot find equivalent JSON Web Algorithm");
+            return Algorithm[algorithm];
+        }
+    }
+}

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Api/Helpers/TokenBuilder.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Api/Helpers/TokenBuilder.cs
@@ -1,0 +1,53 @@
+﻿using SFA.DAS.ProviderApprenticeshipsService.Domain.Interfaces;
+using SFA.DAS.ProviderApprenticeshipsService.Web.Constants;
+using System;
+using System.Security.Cryptography;
+
+namespace SFA.DAS.ProviderApprenticeshipsService.Web.Api.Helpers
+{
+    public interface ITokenBuilder
+    {
+        string CreateToken();
+    }
+
+    public sealed class TokenBuilder: ITokenBuilder
+    {
+        private byte[] SecretKey { get; set; }
+        private readonly ITokenDataSerializer _tokenDataSerializer;
+        private readonly TokenData _tokenData = new TokenData();
+
+        public TokenBuilder(ITokenDataSerializer tokenDataSerializer, IDfESignInServiceConfiguration config)
+        {
+            _tokenDataSerializer = tokenDataSerializer;
+            _tokenData.Header.Add("typ", AuthConfig.TokenType);
+            _tokenData.Header.Add("alg", JsonWebAlgorithm.GetAlgorithm(AuthConfig.Algorithm));
+            _tokenData.Payload.Add("aud", AuthConfig.Aud);
+            _tokenData.Payload.Add("iss", config.DfEOidcConfiguration.ClientId);
+
+            SecretKey = System.Text.Encoding.UTF8.GetBytes(config.DfEOidcConfiguration.ApiServiceSecret);
+        }
+
+        public string CreateToken()
+        {
+            var headerBytes = System.Text.Encoding.UTF8.GetBytes(_tokenDataSerializer.Serialize(_tokenData.Header));
+            var payloadBytes = System.Text.Encoding.UTF8.GetBytes(_tokenDataSerializer.Serialize(_tokenData.Payload));
+            var bytesToSign = System.Text.Encoding.UTF8.GetBytes($"{Base64Encode(headerBytes)}.{Base64Encode(payloadBytes)}");
+            var signedBytes = SignToken(SecretKey, bytesToSign);
+
+            return $"{Base64Encode(headerBytes)}.{Base64Encode(payloadBytes)}.{Base64Encode(signedBytes)}";
+        }
+
+        private static byte[] SignToken(byte[] key, byte[] bytesToSign)
+        {
+            using (var algorithm = HMAC.Create(AuthConfig.Algorithm))
+            {
+                algorithm.Key = key;
+                return algorithm.ComputeHash(bytesToSign);
+            }
+        }
+        private static string Base64Encode(byte[] stringInput)
+        {
+            return Convert.ToBase64String(stringInput).Split(new[] { '=' })[0].Replace('+', '-').Replace('/', '_');
+        }
+    }
+}

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Api/Helpers/TokenData.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Api/Helpers/TokenData.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace SFA.DAS.ProviderApprenticeshipsService.Web.Api.Helpers
+{
+    public class TokenData : ITokenData
+    {
+        public IDictionary<string, object> Header { get; set; }
+
+        public IDictionary<string, object> Payload { get; set; }
+
+        public TokenData() : this(null, null) { }
+
+        public TokenData(IDictionary<string, object> header, IDictionary<string, object> payload)
+        {
+            Header = header ?? new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            Payload = payload ?? new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+        }
+    }
+
+
+    public interface ITokenData
+    {
+        IDictionary<string, object> Header { get; set; }
+        IDictionary<string, object> Payload { get; set; }
+    }
+}

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Api/Helpers/TokenDataSerializer.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Api/Helpers/TokenDataSerializer.cs
@@ -1,0 +1,27 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Linq;
+
+namespace SFA.DAS.ProviderApprenticeshipsService.Web.Api.Helpers
+{
+    public sealed class TokenDataSerializer : ITokenDataSerializer
+    {
+        private readonly JsonSerializer _serializer;
+
+        public TokenDataSerializer() : this(JsonSerializer.CreateDefault()) { }
+
+        public TokenDataSerializer(JsonSerializer serializer)
+        {
+            _serializer = serializer ?? throw new ArgumentNullException("serializer");
+        }
+
+        public string Serialize(object obj) =>
+            JObject.FromObject(obj, _serializer).ToString(_serializer.Formatting, _serializer.Converters.ToArray());
+    }
+
+    public interface ITokenDataSerializer
+    {
+        string Serialize(object obj);
+    }
+}

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Api/Helpers/TokenEncoder.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Api/Helpers/TokenEncoder.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace SFA.DAS.ProviderApprenticeshipsService.Web.Api.Helpers
+{
+    public class TokenEncoder : ITokenEncoder
+    {
+        public string Base64Encode(byte[] stringInput)
+        {
+            if (stringInput == null)
+            {
+                throw new ArgumentNullException("Encoding Error: stringInput");
+            }
+            if (stringInput.Length == 0)
+            {
+                throw new ArgumentOutOfRangeException("Encoding Error: stringInput");
+            }
+            char[] separator = new char[] { '=' };
+            return Convert.ToBase64String(stringInput).Split(separator)[0].Replace('+', '-').Replace('/', '_');
+        }
+    }
+
+    public interface ITokenEncoder
+    {
+        string Base64Encode(byte[] stringInput);
+    }
+}

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Api/Models/ApiServiceResponse.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Api/Models/ApiServiceResponse.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System;
+
+namespace SFA.DAS.ProviderApprenticeshipsService.Web.Api.Models
+{
+    public class ApiServiceResponse
+    {
+        public Guid UserId { get; set; }
+
+        public Guid ServiceId { get; set; }
+
+        public Guid OrganisationId { get; set; }
+
+        public List<Role> Roles { get; set; }
+
+        public List<Identifier> Identifiers { get; set; }
+
+        public List<Status> Status { get; set; }
+    }
+}

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Api/Models/Identifier.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Api/Models/Identifier.cs
@@ -1,0 +1,8 @@
+﻿namespace SFA.DAS.ProviderApprenticeshipsService.Web.Api.Models
+{
+    public class Identifier
+    {
+        public string Key { get; set; }
+        public string Value { get; set; }
+    }
+}

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Api/Models/Organisation.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Api/Models/Organisation.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace SFA.DAS.ProviderApprenticeshipsService.Web.Api.Models
+{
+    public class Organisation
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public string Urn { get; set; }
+        public string Uid { get; set; }
+        public int? UkPrn { get; set; }
+        public string LegacyId { get; set; }
+        public string Sid { get; set; }
+        public string DistrictAdministrative_Code { get; set; }
+    }
+}

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Api/Models/Role.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Api/Models/Role.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace SFA.DAS.ProviderApprenticeshipsService.Web.Api.Models
+{
+    public class Role
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public string Code { get; set; }
+        public int NumericId { get; set; }
+        public Status Status { get; set; }
+    }
+}

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Api/Models/Status.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Api/Models/Status.cs
@@ -1,0 +1,7 @@
+﻿namespace SFA.DAS.ProviderApprenticeshipsService.Web.Api.Models
+{
+    public class Status
+    {
+        public int Id { get; set; }
+    }
+}

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/App_Start/Startup.Auth.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/App_Start/Startup.Auth.cs
@@ -1,18 +1,25 @@
-﻿using System.Linq;
-using System.Threading.Tasks;
-using System.Configuration;
-using Microsoft.IdentityModel.Protocols;
-using Microsoft.Owin.Security;
+﻿using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.Cookies;
 using Microsoft.Owin.Security.Notifications;
 using Microsoft.Owin.Security.WsFederation;
+using Newtonsoft.Json;
+using OpenAthens.Owin.Security.OpenIdConnect;
 using Owin;
 using SFA.DAS.ProviderApprenticeshipsService.Domain.Interfaces;
+using SFA.DAS.ProviderApprenticeshipsService.Infrastructure.Configuration;
+using SFA.DAS.ProviderApprenticeshipsService.Web.Api.Models;
 using SFA.DAS.ProviderApprenticeshipsService.Web.App_Start;
-using SFA.DAS.ProviderApprenticeshipsService.Web.Orchestrators;
-using System.Security.Claims;
+using SFA.DAS.ProviderApprenticeshipsService.Web.Constants;
 using SFA.DAS.ProviderApprenticeshipsService.Web.Extensions;
-using SFA.DAS.ProviderRelationships.Types.Models;
+using SFA.DAS.ProviderApprenticeshipsService.Web.Orchestrators;
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using OpenIdConnectMessage = Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectMessage;
+using WsFederationMessage = Microsoft.IdentityModel.Protocols.WsFederation.WsFederationMessage;
 
 namespace SFA.DAS.ProviderApprenticeshipsService.Web
 {
@@ -21,28 +28,54 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web
         public void ConfigureAuth(IAppBuilder app)
         {
             var logger = StructuremapMvc.StructureMapDependencyScope.Container.GetInstance<IProviderCommitmentsLogger>();
-
+            var dfESignInConfig = StructuremapMvc.StructureMapDependencyScope.Container.GetInstance<IDfESignInServiceConfiguration>();
+            var providerApprenticeshipsServiceConfig = StructuremapMvc.StructureMapDependencyScope.Container.GetInstance<ProviderApprenticeshipsServiceConfiguration>();
             var authenticationOrchestrator = StructuremapMvc.StructureMapDependencyScope.Container.GetInstance<AuthenticationOrchestrator>();
             var accountOrchestrator = StructuremapMvc.StructureMapDependencyScope.Container.GetInstance<AccountOrchestrator>();
 
             app.SetDefaultSignInAsAuthenticationType(CookieAuthenticationDefaults.AuthenticationType);
-
-            app.UseCookieAuthentication(new CookieAuthenticationOptions()
+            app.UseCookieAuthentication(new CookieAuthenticationOptions
             {
                 CookieManager = new SystemWebCookieManager()
             });
 
-            var options = new WsFederationAuthenticationOptions
+            // check if the DfESignIn Switch is available and enabled.
+            if (providerApprenticeshipsServiceConfig != null && providerApprenticeshipsServiceConfig.UseDfESignIn)
             {
-                Wtrealm = ConfigurationManager.AppSettings["IdamsRealm"],
-                MetadataAddress = ConfigurationManager.AppSettings["IdamsADFSMetadata"],
-                Notifications = new WsFederationAuthenticationNotifications
+                var oidcRedirectUrl = ConfigurationManager.AppSettings["IdamsRealm"] + "sign-in";
+                var oidcOptions = new OpenIdConnectAuthenticationOptions
                 {
-                    SecurityTokenValidated = notification => SecurityTokenValidated(notification, logger, authenticationOrchestrator, accountOrchestrator)
-                }
-            };
-
-            app.UseWsFederationAuthentication(options);
+                    Authority = dfESignInConfig.DfEOidcConfiguration.BaseUrl,
+                    ClientId = dfESignInConfig.DfEOidcConfiguration.ClientId,
+                    ClientSecret = dfESignInConfig.DfEOidcConfiguration.Secret,
+                    GetClaimsFromUserInfoEndpoint = true,
+                    PostLogoutRedirectUri = oidcRedirectUrl,
+                    RedirectUri = oidcRedirectUrl,
+                    ResponseType = "code",
+                    Scope = "openid email profile organisation organisationid",
+                    Notifications = new OpenIdConnectAuthenticationNotifications
+                    {
+                        SecurityTokenValidated = async notification =>
+                        {
+                            await PopulateAccountsClaim(notification, logger, authenticationOrchestrator);
+                        }
+                    }
+                };
+                app.UseOpenIdConnectAuthentication(oidcOptions);
+            }
+            else
+            {
+                var options = new WsFederationAuthenticationOptions
+                {
+                    Wtrealm = ConfigurationManager.AppSettings["IdamsRealm"],
+                    MetadataAddress = ConfigurationManager.AppSettings["IdamsADFSMetadata"],
+                    Notifications = new WsFederationAuthenticationNotifications
+                    {
+                        SecurityTokenValidated = notification => SecurityTokenValidated(notification, logger, authenticationOrchestrator, accountOrchestrator)
+                    }
+                };
+                app.UseWsFederationAuthentication(options);
+            }
         }
         
         private async Task SecurityTokenValidated(SecurityTokenValidatedNotification<WsFederationMessage, WsFederationAuthenticationOptions> notification, IProviderCommitmentsLogger logger, 
@@ -67,6 +100,71 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web
             identity.MapClaimToRoles();
 
             await orchestrator.SaveIdentityAttributes(id, parsedUkprn, displayName, email);
+        }
+
+        private async Task PopulateAccountsClaim(SecurityTokenValidatedNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions> notification, IProviderCommitmentsLogger logger,
+            AuthenticationOrchestrator orchestrator)
+        {
+            logger.Info("SecurityTokenValidated notification called");
+
+            #region "READ THE CLAIMS FROM AUTHENTICATION TICKET"
+            var userId = notification.AuthenticationTicket.Identity.GetClaimValue(ClaimName.NameIdentifier);
+            var emailAddress = notification.AuthenticationTicket.Identity.GetClaimValue(ClaimName.Email);
+            var displayName = $"{notification.AuthenticationTicket.Identity.GetClaimValue(ClaimName.GivenName)} {notification.AuthenticationTicket.Identity.GetClaimValue(ClaimName.Surname)}";
+            var userOrganization = JsonConvert.DeserializeObject<Organisation>(notification.AuthenticationTicket.Identity.GetClaimValue(ClaimName.Organisation));
+            #endregion
+
+            var ukPrn = userOrganization.UkPrn != null ? Convert.ToInt64(userOrganization.UkPrn) : 0;
+
+            // if the UserId and User Org Id are available then fetch & add rest of additional claims.
+            if (!string.IsNullOrEmpty(userId) && !string.IsNullOrEmpty(userOrganization.Id.ToString()))
+                await DfEPublicApi(notification, userId, userOrganization.Id.ToString());
+
+            System.Web.HttpContext.Current.Items.Add(ClaimsIdentity.DefaultNameClaimType, ukPrn);
+            System.Web.HttpContext.Current.Items.Add(CustomClaimsIdentity.DisplayName, displayName);
+
+            notification.AuthenticationTicket.Identity.AddClaim(new Claim(ClaimsIdentity.DefaultNameClaimType, ukPrn.ToString()));
+            notification.AuthenticationTicket.Identity.AddClaim(new Claim(CustomClaimsIdentity.DisplayName, displayName));
+            notification.AuthenticationTicket.Identity.AddClaim(new Claim(CustomClaimsIdentity.UkPrn, ukPrn.ToString()));
+          
+            notification.AuthenticationTicket.Identity.MapClaimToRoles();
+
+            // store the identity information in user repository.
+            await orchestrator.SaveIdentityAttributes(userId, ukPrn, displayName, emailAddress);
+        }
+
+        /// <summary>
+        /// Method to get additional claims from DfESignIn Api Service.
+        /// </summary>
+        /// <param name="notification">Security Token.</param>
+        /// <param name="userId">string User Identifier.</param>
+        /// <param name="userOrgId">string User Organization Identifier.</param>
+        /// <returns>Task.</returns>
+        private static async Task DfEPublicApi(SecurityTokenValidatedNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions> notification, string userId, string userOrgId)
+        {
+            var dfESignInService = StructuremapMvc.StructureMapDependencyScope.Container.GetInstance<IDfESignInService>();
+            
+            // fetch the additional claims from DfESignIn Services.
+            var apiServiceResponse = await dfESignInService.Get<ApiServiceResponse>(userId, userOrgId);
+
+            if(apiServiceResponse != null)
+            {
+                var roleClaims = new List<Claim>();
+                foreach (var role in apiServiceResponse.Roles.Where(role => role.Status.Id.Equals(1)))
+                {
+                    // add to current identity because you cannot have multiple identities
+                    roleClaims.Add(new Claim(ClaimName.RoleCode, role.Code, ClaimTypes.Role, notification.Options.ClientId));
+                    roleClaims.Add(new Claim(ClaimName.RoleId, role.Id.ToString(), ClaimTypes.Role, notification.Options.ClientId));
+                    roleClaims.Add(new Claim(ClaimName.RoleName, role.Name, ClaimTypes.Role, notification.Options.ClientId));
+                    roleClaims.Add(new Claim(ClaimName.RoleNumericId, role.NumericId.ToString(), ClaimTypes.Role, notification.Options.ClientId));
+
+                    // add service role claim to initial identity.
+                    notification.AuthenticationTicket.Identity.AddClaim(new Claim(DasClaimTypes.Service, role.Name));
+                }
+
+                // add service role claims to identity.
+                notification.AuthenticationTicket.Identity.AddClaims(roleClaims);
+            }
         }
     }
 }

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Constants/AuthConfig.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Constants/AuthConfig.cs
@@ -1,0 +1,9 @@
+﻿namespace SFA.DAS.ProviderApprenticeshipsService.Web.Constants
+{
+    public static class AuthConfig
+    {
+        public const string Algorithm = "HMACSHA256";
+        public const string Aud = "signin.education.gov.uk";
+        public const string TokenType = "JWT";
+    }
+}

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Constants/ClaimName.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Constants/ClaimName.cs
@@ -1,0 +1,18 @@
+﻿namespace SFA.DAS.ProviderApprenticeshipsService.Web.Constants
+{
+    public static class ClaimName
+    {
+        public const string Sub = "sub";
+        public const string Organisation = "organisation";
+        public const string Email = "email";
+        public const string Given_Name = "given_name";
+        public const string GivenName = "givenname";
+        public const string FamilyName = "family_name";
+        public const string Surname = "surname";
+        public const string RoleCode = "rolecode";
+        public const string RoleId = "roleId";
+        public const string RoleName = "roleName";
+        public const string RoleNumericId = "rolenumericid";
+        public const string NameIdentifier = "nameidentifier";
+    }
+}

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Constants/CustomClaimsIdentity.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Constants/CustomClaimsIdentity.cs
@@ -1,0 +1,9 @@
+﻿namespace SFA.DAS.ProviderApprenticeshipsService.Web.Constants
+{
+    public static class CustomClaimsIdentity
+    {
+        public const string DisplayName = "http://schemas.portal.com/displayname";
+        public const string UkPrn = "http://schemas.portal.com/ukprn";
+        public const string Service = "http://schemas.portal.com/service";
+    }
+}

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Controllers/AccountController.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Controllers/AccountController.cs
@@ -44,17 +44,18 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.Controllers
         {
             var callbackUrl = Url.Action("SignOutCallback", "Account", routeValues: null, protocol: Request.Url.Scheme);
 
+            // check if the DfESignIn configuration exist and enabled.
             if (_configuration != null && _configuration.UseDfESignIn)
             {
                 var authTypes = HttpContext.GetOwinContext().Authentication.GetAuthenticationTypes();
-                HttpContext.GetOwinContext().Authentication.SignOut(new AuthenticationProperties { RedirectUri = callbackUrl }, authTypes.Select(t => t.AuthenticationType).ToArray());
+                HttpContext.GetOwinContext().Authentication.SignOut(
+                    new AuthenticationProperties { RedirectUri = callbackUrl },
+                    authTypes.Select(t => t.AuthenticationType).ToArray());
                 Response.Redirect("/");
             }
             else
             {
-                var auth = Request.GetOwinContext().Authentication;
-
-                auth.SignOut(
+                Request.GetOwinContext().Authentication.SignOut(
                     new AuthenticationProperties { RedirectUri = callbackUrl },
                     WsFederationAuthenticationDefaults.AuthenticationType, CookieAuthenticationDefaults.AuthenticationType);
             }

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Controllers/AccountController.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Controllers/AccountController.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Web;
-using System.Web.Mvc;
-using Microsoft.Owin.Security;
+﻿using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.Cookies;
 using Microsoft.Owin.Security.WsFederation;
 using SFA.DAS.ProviderApprenticeshipsService.Domain.Interfaces;
@@ -14,6 +9,10 @@ using SFA.DAS.ProviderApprenticeshipsService.Web.Models;
 using SFA.DAS.ProviderApprenticeshipsService.Web.Models.Settings;
 using SFA.DAS.ProviderApprenticeshipsService.Web.Models.Types;
 using SFA.DAS.ProviderApprenticeshipsService.Web.Orchestrators;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Web;
+using System.Web.Mvc;
 
 namespace SFA.DAS.ProviderApprenticeshipsService.Web.Controllers
 {
@@ -34,8 +33,8 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.Controllers
         {
             if (!Request.IsAuthenticated)
             {
-                HttpContext.GetOwinContext().Authentication.Challenge(new AuthenticationProperties {RedirectUri = "/"},
-                    WsFederationAuthenticationDefaults.AuthenticationType);
+                HttpContext.GetOwinContext().Authentication.Challenge(new AuthenticationProperties { RedirectUri = "/" },
+                        WsFederationAuthenticationDefaults.AuthenticationType);
             }
         }
 
@@ -49,6 +48,7 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.Controllers
             {
                 var authTypes = HttpContext.GetOwinContext().Authentication.GetAuthenticationTypes();
                 HttpContext.GetOwinContext().Authentication.SignOut(new AuthenticationProperties { RedirectUri = callbackUrl }, authTypes.Select(t => t.AuthenticationType).ToArray());
+                Response.Redirect("/");
             }
             else
             {

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/DependencyResolution/ConfigurationKeys.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/DependencyResolution/ConfigurationKeys.cs
@@ -4,5 +4,6 @@
     {
         public const string CommitmentsApiClient = "SFA.DAS.CommitmentsAPI";
         public const string PasConfiguration = "SFA.DAS.ProviderApprenticeshipsService";
+        public const string DfESignInConfiguration = "SFA.DAS.Provider.DfeSignIn";
     }
 }

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/DependencyResolution/DfESignInApiClientRegistry.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/DependencyResolution/DfESignInApiClientRegistry.cs
@@ -1,0 +1,48 @@
+﻿using SFA.DAS.AutoConfiguration;
+using SFA.DAS.ProviderApprenticeshipsService.Domain.Interfaces;
+using SFA.DAS.ProviderApprenticeshipsService.Infrastructure.Configuration;
+using SFA.DAS.ProviderApprenticeshipsService.Infrastructure.Services;
+using SFA.DAS.ProviderApprenticeshipsService.Web.Api.Helpers;
+using SFA.DAS.ProviderApprenticeshipsService.Web.App_Start;
+using StructureMap;
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+namespace SFA.DAS.ProviderApprenticeshipsService.Web.DependencyResolution
+{
+    public class DfESignInApiClientRegistry : Registry
+    {
+        public DfESignInApiClientRegistry()
+        {
+            For<DfESignInServiceConfiguration>().Use(c => c.GetInstance<IAutoConfigurationService>().Get<DfESignInServiceConfiguration>(ConfigurationKeys.DfESignInConfiguration)).Singleton();
+            For<IDfESignInServiceConfiguration>().Use(c => c.GetInstance<DfESignInServiceConfiguration>());
+            For<IDfESignInService>().Use<DfESignInService>().Ctor<HttpClient>().Is(c => CreateClient());
+            For<ITokenDataSerializer>().Use<TokenDataSerializer>();
+            For<ITokenBuilder>().Use<TokenBuilder>();
+        }
+
+        /// <summary>
+        /// method to create the http client and inject it from constructor.
+        /// </summary>
+        /// <returns>HttpClient.</returns>
+        private static HttpClient CreateClient()
+        {
+            var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", AccessToken());
+            return httpClient;
+        }
+
+        /// <summary>
+        /// method to generate the access token for DfESignIn Service.
+        /// </summary>
+        /// <returns>string.</returns>
+        private static string AccessToken()
+        {
+            var tokenBuilder = StructuremapMvc.StructureMapDependencyScope.Container.GetInstance<ITokenBuilder>();
+            if (tokenBuilder != null) return tokenBuilder.CreateToken();
+            throw new ApplicationException("Token Builder could not be null");
+        }
+    }
+}

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/DependencyResolution/DfESignInApiClientRegistry.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/DependencyResolution/DfESignInApiClientRegistry.cs
@@ -11,6 +11,9 @@ using System.Net.Http.Headers;
 
 namespace SFA.DAS.ProviderApprenticeshipsService.Web.DependencyResolution
 {
+    /// <summary>
+    /// DfESignInApiClientRegistry class to register the dependencies with IOC container.
+    /// </summary>
     public class DfESignInApiClientRegistry : Registry
     {
         public DfESignInApiClientRegistry()
@@ -23,7 +26,7 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.DependencyResolution
         }
 
         /// <summary>
-        /// method to create the http client and inject it from constructor.
+        /// Method to create the http client and inject it from constructor.
         /// </summary>
         /// <returns>HttpClient.</returns>
         private static HttpClient CreateClient()
@@ -35,14 +38,14 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.DependencyResolution
         }
 
         /// <summary>
-        /// method to generate the access token for DfESignIn Service.
+        /// Method to generate the access token for DfESignIn Service.
         /// </summary>
         /// <returns>string.</returns>
         private static string AccessToken()
         {
             var tokenBuilder = StructuremapMvc.StructureMapDependencyScope.Container.GetInstance<ITokenBuilder>();
             if (tokenBuilder != null) return tokenBuilder.CreateToken();
-            throw new ApplicationException("Token Builder could not be null");
+            throw new NullReferenceException($"{nameof(tokenBuilder)} could not be null");
         }
     }
 }

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/DependencyResolution/IoC.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/DependencyResolution/IoC.cs
@@ -33,6 +33,7 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.DependencyResolution
                 c.Policies.Add(new ConfigurationPolicy<ProviderApprenticeshipsServiceConfiguration>("SFA.DAS.ProviderApprenticeshipsService"));
                 c.Policies.Add(new ConfigurationPolicy<AccountApiConfiguration>("SFA.DAS.EmployerAccountAPI"));
                 c.Policies.Add(new ConfigurationPolicy<RoatpCourseManagementWebConfiguration>("SFA.DAS.Roatp.CourseManagement.Web"));
+                c.Policies.Add(new ConfigurationPolicy<DfESignInServiceConfiguration>("SFA.DAS.Provider.DfeSignIn"));
                 c.Policies.Add<CurrentDatePolicy>();
                 c.AddRegistry<AuthorizationRegistry>();
                 c.AddRegistry<ProviderPermissionsAuthorizationRegistry>();
@@ -43,6 +44,7 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.DependencyResolution
                 c.AddRegistry<EncodingRegistry>();
                 c.AddRegistry<ContentApiClientRegistry>();
                 c.AddRegistry<RoatpCourseManagementWebRegistry>();
+                c.AddRegistry<DfESignInApiClientRegistry>();
             });
         }
     }

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Extensions/ClaimsIdentityExtensions.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Extensions/ClaimsIdentityExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Security.Claims;
 using SFA.DAS.ProviderApprenticeshipsService.Web.Authentication;
+using SFA.DAS.ProviderApprenticeshipsService.Web.Constants;
 
 namespace SFA.DAS.ProviderApprenticeshipsService.Web.Extensions
 {
@@ -53,6 +54,12 @@ namespace SFA.DAS.ProviderApprenticeshipsService.Web.Extensions
             {
                 identity.AddClaim(new Claim(ClaimTypes.Role, role));
             }
+        }
+
+        public static string GetClaimValue(this ClaimsIdentity claimsIdentity, string claimName)
+        {
+            var claimValue = claimsIdentity.Claims.Where(c => c.Type.Contains(claimName)).Select(c => c.Value).SingleOrDefault();
+            return claimValue ?? string.Empty;
         }
     }
 }

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/SFA.DAS.ProviderApprenticeshipsService.Web.csproj
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/SFA.DAS.ProviderApprenticeshipsService.Web.csproj
@@ -200,30 +200,43 @@
       <HintPath>..\packages\Microsoft.IdentityModel.Protocol.Extensions.1.0.2.206221351\lib\net45\Microsoft.IdentityModel.Protocol.Extensions.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocols, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Protocols.5.3.0\lib\net461\Microsoft.IdentityModel.Protocols.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Protocols.OpenIdConnect.5.3.0\lib\net461\Microsoft.IdentityModel.Protocols.OpenIdConnect.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocols.WsFederation, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Protocols.WsFederation.5.3.0\lib\net461\Microsoft.IdentityModel.Protocols.WsFederation.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Tokens.5.6.0\lib\net461\Microsoft.IdentityModel.Tokens.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens.Saml, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.Saml.5.3.0\lib\net461\Microsoft.IdentityModel.Tokens.Saml.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Xml, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Xml.5.3.0\lib\net461\Microsoft.IdentityModel.Xml.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Net.Http.Headers, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Net.Http.Headers.2.2.0\lib\netstandard2.0\Microsoft.Net.Http.Headers.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Owin, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.4.2.2\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin.Host.SystemWeb, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.Host.SystemWeb.3.0.1\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Security.3.0.1\lib\net45\Microsoft.Owin.Security.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Owin.Security, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Security.4.2.2\lib\net45\Microsoft.Owin.Security.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin.Security.Cookies, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.Security.Cookies.3.0.1\lib\net45\Microsoft.Owin.Security.Cookies.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security.WsFederation">
-      <HintPath>..\packages\Microsoft.Owin.Security.WsFederation.3.0.1\lib\net45\Microsoft.Owin.Security.WsFederation.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Security.WsFederation, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Security.WsFederation.4.2.2\lib\net45\Microsoft.Owin.Security.WsFederation.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
@@ -258,6 +271,9 @@
     </Reference>
     <Reference Include="NLog.Extensions.Logging, Version=1.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\packages\NLog.Extensions.Logging.1.4.0\lib\net461\NLog.Extensions.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="OpenAthens.Owin.Security.OpenIdConnect, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b145ea713280de0a, processorArchitecture=MSIL">
+      <HintPath>..\packages\OpenAthens.Owin.Security.OpenIdConnect.1.0.0\lib\net45\OpenAthens.Owin.Security.OpenIdConnect.dll</HintPath>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
@@ -434,8 +450,8 @@
       <HintPath>..\packages\System.Globalization.Calendars.4.3.0\lib\net46\System.Globalization.Calendars.dll</HintPath>
     </Reference>
     <Reference Include="System.IdentityModel" />
-    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=4.0.20622.1351, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.4.0.2.206221351\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.3.0\lib\net461\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
     <Reference Include="System.IO, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.4.3.0\lib\net462\System.IO.dll</HintPath>
@@ -473,6 +489,7 @@
     <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Net.NameResolution, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Net.NameResolution.4.0.0\lib\net46\System.Net.NameResolution.dll</HintPath>
       <Private>True</Private>
@@ -521,6 +538,7 @@
       <HintPath>..\packages\System.Runtime.Serialization.Primitives.4.1.1\lib\net46\System.Runtime.Serialization.Primitives.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Security" />
     <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
     </Reference>
@@ -620,6 +638,16 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Api\Helpers\JsonWebAlgorithm.cs" />
+    <Compile Include="Api\Helpers\TokenBuilder.cs" />
+    <Compile Include="Api\Helpers\TokenData.cs" />
+    <Compile Include="Api\Helpers\TokenDataSerializer.cs" />
+    <Compile Include="Api\Helpers\TokenEncoder.cs" />
+    <Compile Include="Api\Models\ApiServiceResponse.cs" />
+    <Compile Include="Api\Models\Identifier.cs" />
+    <Compile Include="Api\Models\Organisation.cs" />
+    <Compile Include="Api\Models\Role.cs" />
+    <Compile Include="Api\Models\Status.cs" />
     <Compile Include="App_Start\BundleConfig.cs" />
     <Compile Include="App_Start\DasClaimTypes.cs" />
     <Compile Include="App_Start\FilterConfig.cs" />
@@ -637,6 +665,9 @@
     <Compile Include="Authentication\RoleNames.cs" />
     <Compile Include="Authentication\ServiceClaims.cs" />
     <Compile Include="Authorization\AuthorizationContextProvider.cs" />
+    <Compile Include="Constants\AuthConfig.cs" />
+    <Compile Include="Constants\ClaimName.cs" />
+    <Compile Include="Constants\CustomClaimsIdentity.cs" />
     <Compile Include="Controllers\AccountController.cs" />
     <Compile Include="Controllers\AgreementController.cs" />
     <Compile Include="Controllers\BaseController.cs" />
@@ -644,6 +675,7 @@
     <Compile Include="Controllers\HomeController.cs" />
     <Compile Include="DependencyResolution\CommitmentsRegistry.cs" />
     <Compile Include="DependencyResolution\ConfigurationKeys.cs" />
+    <Compile Include="DependencyResolution\DfESignInApiClientRegistry.cs" />
     <Compile Include="DependencyResolution\DefaultRegistry.cs" />
     <Compile Include="DependencyResolution\ContentApiClientRegistry.cs" />
     <Compile Include="DependencyResolution\EncodingRegistry.cs" />

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Web.config
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Web.config
@@ -125,7 +125,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.20622.1351" newVersion="4.0.20622.1351" />
+        <bindingRedirect oldVersion="0.0.0.0-5.3.0.0" newVersion="5.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.AI.Agent.Intercept" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -595,6 +595,26 @@
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.0.0" newVersion="5.6.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.0.0" newVersion="5.6.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.0.0" newVersion="5.6.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/packages.config
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/packages.config
@@ -60,17 +60,22 @@
   <package id="Microsoft.IdentityModel.JsonWebTokens" version="5.6.0" targetFramework="net462" />
   <package id="Microsoft.IdentityModel.Logging" version="5.6.0" targetFramework="net462" />
   <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.2.206221351" targetFramework="net45" />
+  <package id="Microsoft.IdentityModel.Protocols" version="5.3.0" targetFramework="net462" />
+  <package id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.3.0" targetFramework="net462" />
+  <package id="Microsoft.IdentityModel.Protocols.WsFederation" version="5.3.0" targetFramework="net462" />
   <package id="Microsoft.IdentityModel.Tokens" version="5.6.0" targetFramework="net462" />
+  <package id="Microsoft.IdentityModel.Tokens.Saml" version="5.3.0" targetFramework="net462" />
+  <package id="Microsoft.IdentityModel.Xml" version="5.3.0" targetFramework="net462" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.3" targetFramework="net452" />
   <package id="Microsoft.Net.Compilers" version="2.7.0" targetFramework="net462" developmentDependency="true" />
   <package id="Microsoft.Net.Http.Headers" version="2.2.0" targetFramework="net462" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.1" targetFramework="net462" />
   <package id="Microsoft.NETCore.Targets" version="1.1.3" targetFramework="net462" />
-  <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
+  <package id="Microsoft.Owin" version="4.2.2" targetFramework="net462" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="3.0.1" targetFramework="net45" />
-  <package id="Microsoft.Owin.Security" version="3.0.1" targetFramework="net45" />
+  <package id="Microsoft.Owin.Security" version="4.2.2" targetFramework="net462" />
   <package id="Microsoft.Owin.Security.Cookies" version="3.0.1" targetFramework="net45" />
-  <package id="Microsoft.Owin.Security.WsFederation" version="3.0.1" targetFramework="net452" />
+  <package id="Microsoft.Owin.Security.WsFederation" version="4.2.2" targetFramework="net462" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" targetFramework="net45" />
@@ -82,6 +87,7 @@
   <package id="NLog.Extensions.Logging" version="1.4.0" targetFramework="net462" />
   <package id="NLog.Schema" version="4.4.12" targetFramework="net462" />
   <package id="NuGet.CommandLine" version="3.3.0" targetFramework="net45" />
+  <package id="OpenAthens.Owin.Security.OpenIdConnect" version="1.0.0" targetFramework="net462" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="Pipelines.Sockets.Unofficial" version="2.2.0" targetFramework="net462" />
   <package id="Polly" version="5.1.0" targetFramework="net45" />
@@ -139,7 +145,7 @@
   <package id="System.Dynamic.Runtime" version="4.0.11" targetFramework="net462" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net462" />
   <package id="System.Globalization.Calendars" version="4.3.0" targetFramework="net462" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="4.0.2.206221351" targetFramework="net462" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="5.3.0" targetFramework="net462" />
   <package id="System.IO" version="4.3.0" targetFramework="net462" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net462" />
   <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net462" />


### PR DESCRIPTION
### Story: The purpose of this story is to put behind a feature toggle the DfE sign in authentication, replacing the existing Pirean, SAML based authentication.
with the DfESignIn Toggle switch, we have an option to swap between SAML based authentication and DfESignIn Authentication.

Link: (https://skillsfundingagency.atlassian.net/browse/FAI-663)
[ProviderApprenticeshipsService]

**Details**

- Extended SFA.DAS.ProviderApprenticeshipsService Config to hold the UseDfeSignIn property. "UseDfeSignIn": true.

- Added logic/condition in Startup.cs to check if the UseDfeSignIn property is set to true, so that DfESignin happens.

- Check the Authentication scheme based on UseDfeSignIn property and use the relevant sign-out Authentication Scheme.