### PR TITLE
FAI-934 Updated the Start/Landing Page Contents

### DIFF
--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/Home/Index.cshtml
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/Home/Index.cshtml
@@ -25,7 +25,9 @@
             Apprenticeship service for training providers: sign in or register for an account
         </h1>
         <div class="inset-text">
-            <p>To access this service, you must be approved as a main provider or employer provider on the <a target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/register-of-apprenticeship-training-providers" class="govuk-link">register of apprenticeship training providers</a>.</p>
+            <p>
+                To access this service, you must be approved as a main provider or employer provider on the <a target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/guidance/apply-to-the-apar-as-an-apprenticeship-training-provider" class="govuk-link">apprenticeship provider and assessment register (APAR).</a>
+            </p>
         </div>
 
         <p>Use this service to:</p>
@@ -37,7 +39,7 @@
             <li>view and respond to employer requests for training</li>
         </ul>
         <p class="gov-body">
-             You'll need a DfE Sign-in to use this service. If you don't have a DfESign-in, you can create one at the next step.
+            You’ll need a DfE Sign-in to use this service. If you don’t have a DfE Sign-in, you can create one at the next step.
         </p>     
         <div class="govuk-form-group">
             <a href="/signin" class="govuk-button govuk-button--start">Start now

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/Home/Index.cshtml
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/Home/Index.cshtml
@@ -39,7 +39,7 @@
             <li>view and respond to employer requests for training</li>
         </ul>
         <p class="gov-body">
-            You’ll need a DfE Sign-in to use this service. If you don’t have a DfE Sign-in, you can create one at the next step.
+            You'll need a DfE Sign-in to use this service. If you don't have a DfE Sign-in, you can create one at the next step.
         </p>     
         <div class="govuk-form-group">
             <a href="/signin" class="govuk-button govuk-button--start">Start now


### PR DESCRIPTION
GIVEN the PAS user has landed on the Start / Landing page after the switch over date to DSI
WHEN they read the content on the page including the banner THEN it will be as specified in the copied doc below

https://skillsfundingagency.atlassian.net/browse/FAI-934
![screencapture-localhost-5011-2023-10-10-14_07_35](https://github.com/SkillsFundingAgency/das-providerapprenticeshipsservice/assets/2102434/ce964c97-523c-4392-95bb-ea71dd9d25ab)
