### PR TITLE
FAI-964 - Bug fix for reading email claim when using dfe sign in

### DIFF
--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/App_Start/DasClaimTypes.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/App_Start/DasClaimTypes.cs
@@ -7,6 +7,7 @@
         public static readonly string DisplayName = "http://schemas.portal.com/displayname";
         public static readonly string Name = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name";
         public static readonly string Email = "http://schemas.portal.com/mail";
+        public static readonly string DfEEmail = "email";
         public static readonly string Ukprn = "http://schemas.portal.com/ukprn";
     }
 }

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Authorization/AuthorizationContextProvider.cs
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Authorization/AuthorizationContextProvider.cs
@@ -81,6 +81,6 @@ public class AuthorizationContextProvider : IAuthorizationContextProvider
 
     private string GetUserEmail()
     {
-        return _httpContextAccessor.HttpContext.User.Identity.GetClaim(DasClaimTypes.Email);
+        return _httpContextAccessor.HttpContext.User.Identity.GetClaim(DasClaimTypes.Email) ?? _httpContextAccessor.HttpContext.User.Identity.GetClaim(DasClaimTypes.DfEEmail);
     }
 }

--- a/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/Account/Index.cshtml
+++ b/src/SFA.DAS.ProviderApprenticeshipsService.Web/Views/Account/Index.cshtml
@@ -145,7 +145,6 @@
     {
         <div class="das-card">
             <h2 class="govuk-heading-m">
-                @* TBC: Employer Demand based on the original config, but unsure which controller action this would be *@
                 <a href="@Url.ProviderFundingLink($"{Model.ProviderId}")" class="govuk-link">Apps Indicative earnings report</a>
             </h2>
             <p>View your expected earnings based on your submission to the Digital apprenticeship service.</p>


### PR DESCRIPTION
Fixes the issue where provider features were not working when dfe sign in was enabled. This was due to the claim name for email being different